### PR TITLE
feat(web): make log timestamp more human readable

### DIFF
--- a/web/shared/components/dialog-web-stream.tsx
+++ b/web/shared/components/dialog-web-stream.tsx
@@ -43,7 +43,7 @@ export const WebStreamDialog = forwardRef<IWebStreamDialog, Props>((props, ref) 
 
     const handleStreamStart = async () => {
         logger.clear()
-        logger.log('started')
+        setConnState('')
         const stream = await navigator.mediaDevices.getDisplayMedia({
             audio: true,
             video: true
@@ -54,6 +54,7 @@ export const WebStreamDialog = forwardRef<IWebStreamDialog, Props>((props, ref) 
         }
         const videoTrack = stream.getVideoTracks()[0]
         setVideoResolution(formatVideoTrackResolution(videoTrack))
+        updateConnState('Started')
         const pc = new RTCPeerConnection()
         pc.addEventListener('iceconnectionstatechange', () => {
             updateConnState(pc.iceConnectionState)

--- a/web/shared/hooks/use-logger.ts
+++ b/web/shared/hooks/use-logger.ts
@@ -1,17 +1,36 @@
 import { useRef, useState } from 'preact/hooks'
 
+const formatTimestamp: (ts: number) => string = ts => {
+    const ms = (ts % 1000).toString(10).padStart(3, '0')
+    let t = Math.trunc(ts / 1000)
+    const s = (t % 60).toString(10).padStart(2, '0')
+    t = Math.trunc(t / 60)
+    const m = (t % 60).toString(10).padStart(2, '0')
+    t = Math.trunc(t / 60)
+    const h = t % 60
+    if (h === 0) {
+        return `${m}:${s}.${ms}`
+    } else {
+        return `${h}:${m}:${s}.${ms}`
+    }
+}
+
 export function useLogger() {
-    const refLastTimestamp = useRef<number>(Infinity)
+    const refFirstTimestamp = useRef<number>(NaN)
     const [logs, setLogs] = useState<string[]>([])
     const clear = () => {
-        refLastTimestamp.current = Infinity
+        refFirstTimestamp.current = NaN
         setLogs([])
     }
     const log = (text: string, time = Date.now()) => {
-        const t = refLastTimestamp.current
-        const diff = time > t ? time - t : 0
-        const line = `${text} (${diff} ms)`
-        refLastTimestamp.current = time
+        const t = refFirstTimestamp.current
+        let diff = 0
+        if (Number.isNaN(t)) {
+            refFirstTimestamp.current = time
+        } else {
+            diff = time - t
+        }
+        const line = `${formatTimestamp(diff)} ${text}`
         setLogs(l => [...l, line])
     }
     return {


### PR DESCRIPTION
<img src="https://github.com/binbat/live777/assets/13914967/b16c442d-10b7-495b-b7d5-18cc16d86843" height="215">

`12:34.567` means `12min 34s 567ms`, hours are omitted when the duration is shorter than 1 hour.
