### PR TITLE
feat(web): stream table manual refresh and cascade dialog improvements

### DIFF
--- a/web/shared/components/dialog-cascade.tsx
+++ b/web/shared/components/dialog-cascade.tsx
@@ -8,75 +8,70 @@ export interface ICascadeDialog {
 }
 
 export const CascadePullDialog = forwardRef<ICascadeDialog>((_props, ref) => {
+    const [streamId, setStreamId] = useState('')
     const [cascadeURL, setCascadeURL] = useState('')
     const refDialog = useRef<HTMLDialogElement>(null)
 
     useImperativeHandle(ref, () => {
         return {
             show: (streamId: string) => {
-                setCascadeURL("pull")
-                if (refDialog.current) {
-                    refDialog.current.onclose = () => {
-                        const target = refDialog.current?.returnValue ?? ''
-                        if (target !== '') {
-                            cascade(target, {
-                                src: location.href + "whep/" + streamId,
-                            })
-                        }
-                    }
-                    refDialog.current.showModal()
-                }
+                setStreamId(streamId)
+                setCascadeURL(`${location.origin}/whep/`)
+                refDialog.current?.showModal()
             }
         }
     })
+
+    const handleStreamIdInputChange = (e: TargetedEvent<HTMLInputElement>) => {
+        setStreamId(e.currentTarget.value)
+    }
 
     const handleURLInputChange = (e: TargetedEvent<HTMLInputElement>) => {
         setCascadeURL(e.currentTarget.value)
     }
 
+    const onConfirmCascadeURL = (_e: Event) => {
+        if (cascadeURL !== '') {
+            cascade(streamId, {
+                src: cascadeURL,
+            })
+        }
+    }
+
     return (
         <dialog ref={refDialog}>
-            <form method="dialog">
-                <h3>Cascade</h3>
-                <p>
-                    <label htmlFor="cascade-url">Stream Id:</label>
+            <h3>Cascade Pull</h3>
+            <p>
+                <label>Stream ID:
                     <br />
-                    <input
-                        type="text"
-                        value={cascadeURL}
-                        id="cascade-url"
-                        className="min-w-sm"
-                        onChange={handleURLInputChange}
-                    />
-                </p>
-                <div>
-                    <button value="">Cancel</button>
-                    <button value={cascadeURL}>Confirm</button>
-                </div>
+                    <input className="min-w-sm" value={streamId} onChange={handleStreamIdInputChange} />
+                </label>
+            </p>
+            <p>
+                <label>Source URL:
+                    <br />
+                    <input className="min-w-sm" value={cascadeURL} onChange={handleURLInputChange} />
+                </label>
+            </p>
+            <form method="dialog">
+                <button>Cancel</button>
+                <button onClick={onConfirmCascadeURL}>Confirm</button>
             </form>
         </dialog>
     )
 })
 
 export const CascadePushDialog = forwardRef<ICascadeDialog>((_props, ref) => {
+    const [streamId, setStreamId] = useState('')
     const [cascadeURL, setCascadeURL] = useState('')
     const refDialog = useRef<HTMLDialogElement>(null)
 
     useImperativeHandle(ref, () => {
         return {
             show: (streamId: string) => {
-                setCascadeURL(location.href + "whip/push")
-                if (refDialog.current) {
-                    refDialog.current.onclose = () => {
-                        const target = refDialog.current?.returnValue ?? ''
-                        if (target !== '') {
-                            cascade(streamId, {
-                                dst: target,
-                            })
-                        }
-                    }
-                    refDialog.current.showModal()
-                }
+                setStreamId(streamId)
+                setCascadeURL(`${location.origin}/whip/push`)
+                refDialog.current?.showModal()
             }
         }
     })
@@ -85,25 +80,26 @@ export const CascadePushDialog = forwardRef<ICascadeDialog>((_props, ref) => {
         setCascadeURL(e.currentTarget.value)
     }
 
+    const onConfirmCascadeURL = (_e: Event) => {
+        if (cascadeURL !== '') {
+            cascade(streamId, {
+                dst: cascadeURL,
+            })
+        }
+    }
+
     return (
         <dialog ref={refDialog}>
-            <form method="dialog">
-                <h3>Cascade</h3>
-                <p>
-                    <label htmlFor="cascade-url">Target URL:</label>
+            <h3>Cascade Push ({streamId})</h3>
+            <p>
+                <label>Target URL:
                     <br />
-                    <input
-                        type="text"
-                        value={cascadeURL}
-                        id="cascade-url"
-                        className="min-w-sm"
-                        onChange={handleURLInputChange}
-                    />
-                </p>
-                <div>
-                    <button value="">Cancel</button>
-                    <button value={cascadeURL}>Confirm</button>
-                </div>
+                    <input className="min-w-sm" value={cascadeURL} onChange={handleURLInputChange} />
+                </label>
+            </p>
+            <form method="dialog">
+                <button>Cancel</button>
+                <button onClick={onConfirmCascadeURL}>Confirm</button>
             </form>
         </dialog>
     )

--- a/web/shared/components/streams-table.tsx
+++ b/web/shared/components/streams-table.tsx
@@ -11,7 +11,7 @@ import { IWebStreamDialog, WebStreamDialog } from './dialog-web-stream'
 import { INewStreamDialog, NewStreamDialog } from './dialog-new-stream'
 
 export function StreamsTable() {
-    const [streams, isRefreshingStreams, toggleRefreshStreams] = useRefreshTimer([], getStreams)
+    const streams = useRefreshTimer([], getStreams)
     const [selectedStreamId, setSelectedStreamId] = useState('')
     const refCascadePull = useRef<ICascadeDialog>(null)
     const refCascadePush = useRef<ICascadeDialog>(null)
@@ -56,7 +56,7 @@ export function StreamsTable() {
 
     const handleNewStream = () => {
         const prefix = 'web-'
-        const existingIds = webStreams.concat(streams.filter(s => s.id.startsWith(prefix)).map(s => s.id))
+        const existingIds = webStreams.concat(streams.data.filter(s => s.id.startsWith(prefix)).map(s => s.id))
         let i = 0
         let newStreamId = `${prefix}${i}`
         while (existingIds.includes(newStreamId)) {
@@ -103,7 +103,7 @@ export function StreamsTable() {
 
     return (
         <>
-            <ClientsDialog ref={refClients} id={selectedStreamId} sessions={streams.find(s => s.id == selectedStreamId)?.subscribe.sessions ?? []} />
+            <ClientsDialog ref={refClients} id={selectedStreamId} sessions={streams.data.find(s => s.id == selectedStreamId)?.subscribe.sessions ?? []} />
 
             <CascadePullDialog ref={refCascadePull} />
             <CascadePushDialog ref={refCascadePush} />
@@ -139,9 +139,10 @@ export function StreamsTable() {
             )}
 
             <fieldset>
-                <legend class="inline-flex items-center">
-                    <span>Streams (total: {streams.length})</span>
-                    <StyledCheckbox label="Auto Refresh" checked={isRefreshingStreams} onClick={toggleRefreshStreams}></StyledCheckbox>
+                <legend class="inline-flex items-center gap-x-4">
+                    <span>Streams (total: {streams.data.length})</span>
+                    <button onClick={() => streams.updateData()}>Refresh</button>
+                    <StyledCheckbox label="Auto Refresh" checked={streams.isRefreshing} onClick={streams.toggleTimer}></StyledCheckbox>
                 </legend>
                 <table>
                     <thead>
@@ -155,7 +156,7 @@ export function StreamsTable() {
                         </tr>
                     </thead>
                     <tbody>
-                        {streams.map(i =>
+                        {streams.data.map(i =>
                             <tr>
                                 <td class="text-center">{i.id}</td>
                                 <td class="text-center">{i.publish.sessions.length}</td>

--- a/web/shared/components/streams-table.tsx
+++ b/web/shared/components/streams-table.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'preact/hooks'
 
 import { getStreams, deleteStream } from '../api'
-import { formatTime } from '../utils'
+import { formatTime, nextSeqId } from '../utils'
 import { useRefreshTimer } from '../hooks/use-refresh-timer'
 import { StyledCheckbox } from './styled-checkbox'
 import { IClientsDialog, ClientsDialog } from './dialog-clients'
@@ -29,9 +29,11 @@ export function StreamsTable() {
         refClients.current?.show()
     }
 
-    const handleCascadePullStream = (id: string) => {
-        refCascadePull.current?.show(id)
+    const handleCascadePullStream = () => {
+        const newStreamId = nextSeqId('pull-', streams.data.map(s => s.id))
+        refCascadePull.current?.show(newStreamId)
     }
+
     const handleCascadePushStream = (id: string) => {
         refCascadePush.current?.show(id)
     }
@@ -55,14 +57,7 @@ export function StreamsTable() {
     }
 
     const handleNewStream = () => {
-        const prefix = 'web-'
-        const existingIds = webStreams.concat(streams.data.filter(s => s.id.startsWith(prefix)).map(s => s.id))
-        let i = 0
-        let newStreamId = `${prefix}${i}`
-        while (existingIds.includes(newStreamId)) {
-            i++
-            newStreamId = `${prefix}${i}`
-        }
+        const newStreamId = nextSeqId('web-', webStreams.concat(streams.data.map(s => s.id)))
         refNewStream.current?.show(newStreamId)
     }
 
@@ -169,7 +164,6 @@ export function StreamsTable() {
                                 <td>
                                     <button onClick={() => handlePreview(i.id)} class={previewStreams.includes(i.id) ? 'text-blue-500' : undefined} >Preview</button>
                                     <button onClick={() => handleViewClients(i.id)}>Clients</button>
-                                    <button onClick={() => handleCascadePullStream(i.id)}>Cascade Pull</button>
                                     <button onClick={() => handleCascadePushStream(i.id)}>Cascade Push</button>
                                     <button onClick={() => handleOpenPlayerPage(i.id)}>Player</button>
                                     <button onClick={() => handleOpenDebuggerPage(i.id)}>Debugger</button>
@@ -180,6 +174,7 @@ export function StreamsTable() {
                     </tbody>
                 </table>
                 <div>
+                    <button onClick={handleCascadePullStream}>Cascade Pull</button>
                     <button onClick={handleNewStream}>New Stream</button>
                     {webStreams.map(s =>
                         <button onClick={() => { handleOpenWebStream(s) }}>{s}</button>

--- a/web/shared/components/styled-checkbox.tsx
+++ b/web/shared/components/styled-checkbox.tsx
@@ -8,7 +8,7 @@ export interface StyledCheckboxProps {
 
 export function StyledCheckbox({ label, checked, onClick }: StyledCheckboxProps) {
     return (
-        <label class="ml-10 inline-flex items-center cursor-pointer">
+        <label class="inline-flex items-center cursor-pointer">
             <input type="checkbox" class="sr-only peer" checked={checked} onClick={onClick} />
             <div class="relative w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer dark:bg-gray-700 peer-checked:after:translate-x-full rtl:peer-checked:after:-translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all dark:border-gray-600 peer-checked:bg-blue-600"></div>
             <span class="ml-2">{label}</span>

--- a/web/shared/hooks/use-refresh-timer.ts
+++ b/web/shared/hooks/use-refresh-timer.ts
@@ -1,16 +1,16 @@
 import { useEffect, useState } from 'preact/hooks';
 
-export function useRefreshTimer<T>(initial: T, fetchContent: () => Promise<T>, timeout = 3000, immediate = true): [T, boolean, () => void] {
-    const [content, setContent] = useState<T>(initial)
+export function useRefreshTimer<T>(initial: T, fetchData: () => Promise<T>, timeout = 3000, immediate = true) {
+    const [data, setData] = useState<T>(initial)
     const [isImmediate, _setIsImmediate] = useState(immediate)
     const [refreshTimer, setRefreshTimer] = useState(-1)
     const isRefreshing = refreshTimer > 0
-    const updateContent = async () => {
-        setContent(await fetchContent())
+    const updateData = async () => {
+        setData(await fetchData())
     }
     useEffect(() => {
         if (isImmediate) {
-            updateContent()
+            updateData()
         }
         return () => {
             if (isRefreshing) {
@@ -21,7 +21,7 @@ export function useRefreshTimer<T>(initial: T, fetchContent: () => Promise<T>, t
     useEffect(() => {
         if (isRefreshing) {
             clearInterval(refreshTimer)
-            setRefreshTimer(window.setInterval(updateContent, timeout))
+            setRefreshTimer(window.setInterval(updateData, timeout))
         }
     }, [timeout])
     const toggleTimer = () => {
@@ -29,9 +29,14 @@ export function useRefreshTimer<T>(initial: T, fetchContent: () => Promise<T>, t
             clearInterval(refreshTimer)
             setRefreshTimer(-1)
         } else {
-            updateContent()
-            setRefreshTimer(window.setInterval(updateContent, timeout))
+            updateData()
+            setRefreshTimer(window.setInterval(updateData, timeout))
         }
     }
-    return [content, isRefreshing, toggleTimer]
+    return {
+        data,
+        isRefreshing,
+        updateData,
+        toggleTimer
+    }
 }

--- a/web/shared/utils.ts
+++ b/web/shared/utils.ts
@@ -15,3 +15,13 @@ export const formatVideoTrackResolution = (track: MediaStreamTrack): string => {
     if (!frameRate) return `${width}x${height}`
     return `${width}x${height}@${frameRate}`
 }
+
+export const nextSeqId = (prefix: string, existingIds: string[]) => {
+    let i = 0
+    let newId = `${prefix}${i}`
+    while (existingIds.includes(newId)) {
+        i++
+        newId = `${prefix}${i}`
+    }
+    return newId
+}


### PR DESCRIPTION
Added stream table manual refresh button; moved "Cascade Pull" button to bottom of the table

![image](https://github.com/binbat/live777/assets/13914967/88ec31cf-fb2b-41c5-b720-e8a39afc870a)

"Cascade Pull" dialog acceps "Stream ID" and "Source URL" input

<img src="https://github.com/binbat/live777/assets/13914967/b59d278d-4116-47a9-b7a1-b380f58f6d6a" height="280">

"Cascade Push" dialog shows source stream ID on its title

<img src="https://github.com/binbat/live777/assets/13914967/6549dfd1-1cb3-4732-98ed-d376fe8eef86" height="219">
