### PR TITLE
fix(web): handle audio tracks correctly

### DIFF
--- a/web/shared/components/dialog-web-stream.tsx
+++ b/web/shared/components/dialog-web-stream.tsx
@@ -52,15 +52,18 @@ export const WebStreamDialog = forwardRef<IWebStreamDialog, Props>((props, ref) 
         if (refVideo.current) {
             refVideo.current.srcObject = stream;
         }
-        const videoTrack = stream.getVideoTracks()[0];
-        setVideoResolution(formatVideoTrackResolution(videoTrack));
         updateConnState('Started');
         const pc = new RTCPeerConnection();
         pc.addEventListener('iceconnectionstatechange', () => {
             updateConnState(pc.iceConnectionState);
         });
-        pc.addTransceiver(videoTrack, { direction: 'sendonly' });
-        stream.getAudioTracks().forEach(track => pc.addTrack(track));
+        stream.getVideoTracks().forEach(vt => {
+            pc.addTransceiver(vt, { direction: 'sendonly' });
+            setVideoResolution(formatVideoTrackResolution(vt));
+        });
+        stream.getAudioTracks().forEach(at => {
+            pc.addTransceiver(at, { direction: 'sendonly' });
+        });
         const whip = new WHIPClient();
         const url = `${location.origin}/whip/${streamId}`;
         const token = '';

--- a/web/shared/tools/debugger/debugger.js
+++ b/web/shared/tools/debugger/debugger.js
@@ -232,13 +232,16 @@ async function startWhep() {
     document.getElementById(idWhepDataChannel).dataChannel = pc.createDataChannel("")
 
     pc.oniceconnectionstatechange = e => logWhep(num, pc.iceConnectionState)
-    pc.addTransceiver('video', {'direction': 'recvonly'})
-    pc.addTransceiver('audio', {'direction': 'recvonly'})
+    pc.addTransceiver("video", { "direction": "recvonly" })
+    pc.addTransceiver("audio", { "direction": "recvonly" })
+
+    const ms = new MediaStream();
     pc.ontrack = ev => {
         logWhep(num, `track: ${ev.track.kind}`)
-        if (ev.track.kind === "video") {
-            if (ev.streams.length !== 0) document.getElementById("whep-video-player").srcObject = ev.streams[0]
-        }
+        ms.addTrack(ev.track);
+        // addtrack removetrack events won't fire when calling addTrack/removeTrack in javascript
+        // https://github.com/w3c/mediacapture-main/issues/517
+        document.getElementById("whep-video-player").srcObject = ms;
     }
     const whep = new WHEPClient()
     const url = location.origin + "/whep/" + streamId


### PR DESCRIPTION
Add audio and video tracks to `MediaStream` and use it for `srcObject` of `<video>` element