### PR TITLE
feat(web): initial support for end to end latency measuring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@binbat/whip-whep": "^1.1.1-sdp-trickle-throw",
+        "@nuintun/qrcode": "^4.1.5",
         "preact": "^10.23.2",
+        "typescript-event-target": "^1.1.1",
         "wretch": "^2.9.1"
       },
       "devDependencies": {
@@ -1570,6 +1572,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@nuintun/qrcode": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@nuintun/qrcode/-/qrcode-4.1.5.tgz",
+      "integrity": "sha512-OwndHjvVjYIqXIaWdjLRCDXKoBqnWZTQcNGp3JxQl94WdYHT5rkjuPUKudBTuZNkNLSZvr6lJne62omuFNckOw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.3"
       }
     },
     "node_modules/@polka/url": {
@@ -5621,6 +5632,12 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD"
+    },
     "node_modules/tsx": {
       "version": "4.19.0",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.0.tgz",
@@ -6122,6 +6139,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/typescript-event-target": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/typescript-event-target/-/typescript-event-target-1.1.1.tgz",
+      "integrity": "sha512-dFSOFBKV6uwaloBCCUhxlD3Pr/P1a/tJdcmPrTXCHlEFD3faj0mztjcGn6VBAhQ0/Bdy8K3VWrrqwbt/ffsYsg==",
+      "license": "MIT"
     },
     "node_modules/ufo": {
       "version": "1.5.4",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,9 @@
   },
   "dependencies": {
     "@binbat/whip-whep": "^1.1.1-sdp-trickle-throw",
+    "@nuintun/qrcode": "^4.1.5",
     "preact": "^10.23.2",
+    "typescript-event-target": "^1.1.1",
     "wretch": "^2.9.1"
   },
   "devDependencies": {

--- a/web/shared/qrcode-stream.ts
+++ b/web/shared/qrcode-stream.ts
@@ -143,8 +143,11 @@ export class QRCodeStreamDecoder extends TypedEventTarget<QRCodeStreamDecoderEve
         // TODO: make it configurable
         if (this.seq >= 5) {
             this.seq = 0;
-            const now = Date.now();
-            this.decodeFrame(now, metadata.width, metadata.height);
+            try {
+                this.decodeFrame(Date.now(), metadata.width, metadata.height);
+            } catch (e) {
+                console.log(e);
+            }
         }
         if (this.scheduled) {
             this.video.requestVideoFrameCallback(this.videoFrameCallback);

--- a/web/shared/qrcode-stream.ts
+++ b/web/shared/qrcode-stream.ts
@@ -1,0 +1,168 @@
+import { Encoder, Numeric, binarize, Decoder, Detector, grayscale } from '@nuintun/qrcode';
+import { TypedEventTarget } from "typescript-event-target";
+
+export class QRCodeStream {
+
+    static White = '#fff';
+    static Black = '#000';
+
+    private encoder: Encoder;
+    private width: number;
+    private height: number;
+    private ctx: CanvasRenderingContext2D;
+    private qrSize: number;
+    private qrMarginX: number;
+    private qrMarginY: number;
+
+    private scheduled = false;
+    private frameRequestCallback: FrameRequestCallback;
+
+    private capturing: MediaStream | null = null;
+
+    constructor(public canvas: HTMLCanvasElement) {
+        this.encoder = new Encoder({ level: 'L' });
+        const { width, height } = canvas;
+        this.width = width;
+        this.height = height;
+        this.ctx = this.canvas.getContext('2d')!;
+        this.qrSize = Math.min(width, height);
+        this.qrMarginX = (width - this.qrSize) / 2;
+        this.qrMarginY = (height - this.qrSize) / 2;
+        this.frameRequestCallback = this.frameRequestCallback_unbound.bind(this);
+    }
+
+    private doFrame(now: number) {
+        const str = now.toString();
+        const qr = this.encoder.encode(new Numeric(str));
+        this.ctx.fillStyle = QRCodeStream.White;
+        this.ctx.fillRect(0, 0, this.width, this.height);
+        this.ctx.fillStyle = QRCodeStream.Black;
+        const bitmapSize = qr.size;
+        const pixelSize = Math.max(1, Math.trunc(this.qrSize / bitmapSize));
+        for (let i = 0; i < bitmapSize; i++) {
+            for (let j = 0; j < bitmapSize; j++) {
+                if (qr.get(i, j) === 1) {
+                    this.ctx.fillRect(
+                        this.qrMarginX + pixelSize * i,
+                        this.qrMarginY + pixelSize * j,
+                        pixelSize, pixelSize
+                    );
+                }
+            }
+        }
+    }
+
+    private frameRequestCallback_unbound(_time: DOMHighResTimeStamp) {
+        const now = Date.now();
+        this.doFrame(now);
+        if (this.scheduled) {
+            window.requestAnimationFrame(this.frameRequestCallback);
+        }
+    }
+
+    public capture() {
+        if (this.capturing) {
+            return this.capturing;
+        }
+        if (!this.scheduled) {
+            this.scheduled = true;
+            window.requestAnimationFrame(this.frameRequestCallback);
+        }
+        const ms = this.canvas.captureStream();
+        this.capturing = ms;
+        return ms;
+    }
+
+    public stop() {
+        if (this.scheduled) {
+            this.scheduled = false;
+        }
+        if (this.capturing) {
+            this.capturing.getTracks().forEach(t => t.stop());
+            this.capturing = null;
+        }
+    }
+
+}
+
+const QRCodeStreamDecoderEvents = {
+    Latency: 'latency'
+} as const;
+
+interface QRCodeStreamDecoderEventMap {
+    [QRCodeStreamDecoderEvents.Latency]: CustomEvent<number>;
+}
+
+export class QRCodeStreamDecoder extends TypedEventTarget<QRCodeStreamDecoderEventMap> {
+
+    private detector: Detector;
+    private decoder: Decoder;
+    private canvas: OffscreenCanvas;
+    private ctx: OffscreenCanvasRenderingContext2D;
+
+    private scheduled = false;
+    private videoFrameCallback: VideoFrameRequestCallback;
+
+    private seq = 0;
+
+    constructor(public video: HTMLVideoElement) {
+        super();
+        this.detector = new Detector();
+        this.decoder = new Decoder();
+        this.canvas = new OffscreenCanvas(video.width, video.height);
+        this.ctx = this.canvas.getContext('2d', { willReadFrequently: true })!;
+        this.videoFrameCallback = this.videoFrameCallback_unbound.bind(this);
+    }
+
+    private emitLatencyEvent(detail: number) {
+        this.dispatchTypedEvent(
+            QRCodeStreamDecoderEvents.Latency,
+            new CustomEvent(QRCodeStreamDecoderEvents.Latency, { detail })
+        );
+    }
+
+    // TODO: move decoding to worker
+    private decodeFrame(now: number, width: number, height: number) {
+        this.canvas.width = width;
+        this.canvas.height = height;
+        this.ctx.drawImage(this.video, 0, 0, width, height);
+        const imageData = this.ctx.getImageData(0, 0, width, height);
+        const luminances = grayscale(imageData);
+        const binarized = binarize(luminances, width, height);
+        // assume only one QR Code per frame
+        const detected = this.detector.detect(binarized).next().value;
+        if (detected) {
+            const decoded = this.decoder.decode(detected.matrix);
+            const latency = now - Number.parseInt(decoded.content, 10);
+            this.emitLatencyEvent(latency);
+        }
+    }
+
+    private videoFrameCallback_unbound(_now: DOMHighResTimeStamp, metadata: VideoFrameCallbackMetadata) {
+        this.seq++;
+        // TODO: make it configurable
+        if (this.seq >= 5) {
+            this.seq = 0;
+            const now = Date.now();
+            this.decodeFrame(now, metadata.width, metadata.height);
+        }
+        if (this.scheduled) {
+            this.video.requestVideoFrameCallback(this.videoFrameCallback);
+        }
+    }
+
+    public start() {
+        if (this.scheduled) {
+            return;
+        }
+        this.scheduled = true;
+        this.video.requestVideoFrameCallback(this.videoFrameCallback);
+    }
+
+    public stop() {
+        if (!this.scheduled) {
+            return;
+        }
+        this.scheduled = false;
+    }
+}


### PR DESCRIPTION
Encode current timestamp with QR Code, and decode the timestamp on receiver side. Fixes #138

## Usage

1. Create a new web stream, then start the stream with "Encode Latency"
    <img src="https://github.com/user-attachments/assets/b7d3e1cc-ed9d-4b5c-b33b-34bbdad0a588" width="340">

2. "Preview" the stream, and press "Decode Latency"
![image](https://github.com/user-attachments/assets/5eefbda0-fde8-4c5a-bb04-9c8d2b31f25b)
