### PR TITLE
fix(web): avoid assigning srcObject of debug-player repeatedly

### DIFF
--- a/web/shared/tools/debugger/debugger.js
+++ b/web/shared/tools/debugger/debugger.js
@@ -207,12 +207,13 @@ async function startWhep() {
     pc.addTransceiver("audio", { "direction": "recvonly" })
 
     const ms = new MediaStream();
+    document.getElementById("whep-video-player").srcObject = ms;
     pc.ontrack = ev => {
         logWhep(num, `track: ${ev.track.kind}`)
         ms.addTrack(ev.track);
         // addtrack removetrack events won't fire when calling addTrack/removeTrack in javascript
         // https://github.com/w3c/mediacapture-main/issues/517
-        document.getElementById("whep-video-player").srcObject = ms;
+        document.getElementById("whep-video-player").setShowTrackCount(ms);
     }
     const whep = new WHEPClient()
     const url = location.origin + "/whep/" + streamId


### PR DESCRIPTION
fixes #225 playing audio only streams in web debugger