### PR TITLE
feat(liveman): change api node strategy

### DIFF
--- a/liveman/src/store.rs
+++ b/liveman/src/store.rs
@@ -32,8 +32,8 @@ pub struct Node {
     pub url: String,
 
     streams: Vec<Stream>,
-    strategy: Option<Strategy>,
-    duration: Option<Duration>,
+    pub strategy: Option<Strategy>,
+    pub duration: Option<Duration>,
 }
 
 impl Node {

--- a/web/liveman/api.ts
+++ b/web/liveman/api.ts
@@ -23,8 +23,8 @@ export function login(username: string, password: string) {
 export interface Node {
     alias: string;
     url: string;
-    duration: String;
-    strategy: any,
+    duration: string;
+    strategy: Record<string, string | number | boolean>,
     status: 'running' | 'stopped';
 }
 

--- a/web/liveman/api.ts
+++ b/web/liveman/api.ts
@@ -23,8 +23,8 @@ export function login(username: string, password: string) {
 export interface Node {
     alias: string;
     url: string;
-    pub_max: number;
-    sub_max: number;
+    duration: String;
+    strategy: any,
     status: 'running' | 'stopped';
 }
 

--- a/web/liveman/components/nodes-table.tsx
+++ b/web/liveman/components/nodes-table.tsx
@@ -53,7 +53,7 @@ type NodeStrategyTableProps = Pick<Node, 'strategy'>;
 function NodeStrategyTable({ strategy }: NodeStrategyTableProps) {
     return (
         <div class="h-[1lh] overflow-hidden relative group hover:overflow-visible">
-            <table class="mx-auto px-1 bg-neutral-800 rounded group-hover:absolute group-hover:inset-x-0 group-hover:z-1 group-hover:outline group-hover:outline-indigo-500">
+            <table class="mx-auto px-1 bg-white @dark:bg-neutral-800 rounded group-hover:absolute group-hover:inset-x-0 group-hover:z-1 group-hover:outline group-hover:outline-indigo-500">
                 <tbody>
                     {Object.entries(strategy).map(([k, v]) => (
                         <tr>

--- a/web/liveman/components/nodes-table.tsx
+++ b/web/liveman/components/nodes-table.tsx
@@ -1,7 +1,7 @@
 import { useRefreshTimer } from '../../shared/hooks/use-refresh-timer';
 import { StyledCheckbox } from '../../shared/components/styled-checkbox';
 
-import { getNodes } from '../api';
+import { type Node, getNodes } from '../api';
 
 async function getNodesSorted() {
     const nodes = await getNodes();
@@ -25,7 +25,7 @@ export function NodesTable() {
                             <th class="min-w-24">Alias</th>
                             <th class="min-w-24">Status</th>
                             <th>Delay</th>
-                            <th>Strategy</th>
+                            <th class="min-w-72">Strategy</th>
                             <th class="min-w-72">API URL</th>
                         </tr>
                     </thead>
@@ -35,7 +35,9 @@ export function NodesTable() {
                                 <td class="text-center">{n.alias}</td>
                                 <td class="text-center">{n.status}</td>
                                 <td class="text-center">{n.duration}ms</td>
-                                <td class="text-center">{JSON.stringify(n.strategy)}</td>
+                                <td class="text-center">
+                                    <NodeStrategyTable strategy={n.strategy} />
+                                </td>
                                 <td class="text-center"><a href={n.url} target="_blank">{n.url}</a></td>
                             </tr>
                         ))}
@@ -43,5 +45,24 @@ export function NodesTable() {
                 </table>
             </fieldset>
         </>
+    );
+}
+
+type NodeStrategyTableProps = Pick<Node, 'strategy'>;
+
+function NodeStrategyTable({ strategy }: NodeStrategyTableProps) {
+    return (
+        <div class="h-[1lh] overflow-hidden relative group hover:overflow-visible">
+            <table class="mx-auto px-1 bg-neutral-800 rounded group-hover:absolute group-hover:inset-x-0 group-hover:z-1 group-hover:outline group-hover:outline-indigo-500">
+                <tbody>
+                    {Object.entries(strategy).map(([k, v]) => (
+                        <tr>
+                            <th class="text-left">{k}</th>
+                            <td>{`${v}`}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
     );
 }

--- a/web/liveman/components/nodes-table.tsx
+++ b/web/liveman/components/nodes-table.tsx
@@ -24,8 +24,8 @@ export function NodesTable() {
                         <tr>
                             <th class="min-w-24">Alias</th>
                             <th class="min-w-24">Status</th>
-                            <th>Max Publish Cnt.</th>
-                            <th>Max subscribe Cnt.</th>
+                            <th>Delay</th>
+                            <th>Strategy</th>
                             <th class="min-w-72">API URL</th>
                         </tr>
                     </thead>
@@ -34,8 +34,8 @@ export function NodesTable() {
                             <tr>
                                 <td class="text-center">{n.alias}</td>
                                 <td class="text-center">{n.status}</td>
-                                <td class="text-center">{n.pub_max}</td>
-                                <td class="text-center">{n.sub_max}</td>
+                                <td class="text-center">{n.duration}ms</td>
+                                <td class="text-center">{JSON.stringify(n.strategy)}</td>
                                 <td class="text-center"><a href={n.url} target="_blank">{n.url}</a></td>
                             </tr>
                         ))}


### PR DESCRIPTION
I want to a any `key/value` display for strategy

Maybe float window is ok

@rocka 

<img width="1728" alt="Screenshot 2024-10-24 at 23 49 17" src="https://github.com/user-attachments/assets/72ba0626-104d-49ec-819d-4620478d28d1">
