### PR TITLE
refactor: use format_args!() when String creation is unnecessary

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -54,3 +54,4 @@ Example:
 - Rocket Aaron, @rocka, 2024/04/22
 - Likai Zhao, @agougougoua, 2024/05/09
 - Yihan Wen, @udrs, 2024/6/21
+- George Hu, @Integral-Tech, 2024/12/21

--- a/livetwo/src/rtspclient.rs
+++ b/livetwo/src/rtspclient.rs
@@ -52,24 +52,23 @@ impl RtspSession {
     }
 
     fn generate_digest_response(&self, realm: &str, nonce: &str, method: &str) -> String {
-        let ha1 = format!("{:x}", {
+        format!("{:x}", {
             let mut hasher = Md5::new();
             hasher.update(format!(
                 "{}:{}:{}",
-                self.auth_params.username, realm, self.auth_params.password
+                format_args!("{:x}", {
+                    let hasher = Md5::new_with_prefix(format!(
+                        "{}:{}:{}",
+                        self.auth_params.username, realm, self.auth_params.password
+                    ));
+                    hasher.finalize()
+                }),
+                nonce,
+                format_args!("{:x}", {
+                    let hasher = Md5::new_with_prefix(format!("{}:{}", method, self.uri));
+                    hasher.finalize()
+                })
             ));
-            hasher.finalize()
-        });
-
-        let ha2 = format!("{:x}", {
-            let mut hasher = Md5::new();
-            hasher.update(format!("{}:{}", method, self.uri));
-            hasher.finalize()
-        });
-
-        format!("{:x}", {
-            let mut hasher = Md5::new();
-            hasher.update(format!("{}:{}:{}", ha1, nonce, ha2));
             hasher.finalize()
         })
     }

--- a/livetwo/src/rtspclient.rs
+++ b/livetwo/src/rtspclient.rs
@@ -454,10 +454,7 @@ fn generate_digest_response(
         hasher.update(format!(
             "{}:{}:{}",
             format_args!("{:x}", {
-                let hasher = Md5::new_with_prefix(format!(
-                    "{}:{}:{}",
-                    username, realm, password
-                ));
+                let hasher = Md5::new_with_prefix(format!("{}:{}:{}", username, realm, password));
                 hasher.finalize()
             }),
             nonce,


### PR DESCRIPTION
- When String creation is unnecessary, replace `format!()` with `format_args!()` to avoid overhead of heap allocation.