### PR TITLE
feat(web): persist token to localStorage

### DIFF
--- a/web/liveman/components/login.tsx
+++ b/web/liveman/components/login.tsx
@@ -26,7 +26,7 @@ function useInput(label: string, type = 'text') {
 
 export interface LoginProps {
     show: boolean;
-    onSuccess?: (token: string) => void;
+    onSuccess?: (tokenType: string, tokenValue: string) => void;
 }
 
 export function Login({ show, onSuccess }: LoginProps) {
@@ -76,7 +76,7 @@ export function Login({ show, onSuccess }: LoginProps) {
             const tk = `${tokenType} ${tokenValue}`;
             livemanApi.setAuthToken(tk);
             sharedApi.setAuthToken(tk);
-            onSuccess?.(tokenValue);
+            onSuccess?.(tokenType, tokenValue);
         } catch (e) {
             livemanApi.setAuthToken('');
             sharedApi.setAuthToken('');

--- a/web/liveman/components/nodes-table.tsx
+++ b/web/liveman/components/nodes-table.tsx
@@ -18,9 +18,7 @@ export function NodesTable() {
     const tokenContext = useContext(TokenContext);
 
     useEffect(() => {
-        if (tokenContext.token.length > 0) {
-            nodes.updateData();
-        }
+        nodes.updateData();
     }, [tokenContext.token]);
 
     return (
@@ -57,7 +55,7 @@ export function NodesTable() {
                             <span>{n.status}</span>
                             <span>{n.duration}</span>
                             <NodeStrategyLabel strategy={n.strategy} />
-                            <Link href={location.href + '?nodes=' + n.alias} target="_blank">{location.href + '?nodes=' + n.alias}</Link>
+                            <NodeLink node={n} />
                         </Table.Row>
                     ) : <tr><td colspan={5} className="text-center">N/A</td></tr>}
                 </Table.Body>
@@ -76,7 +74,6 @@ function NodeStrategyLabel({ strategy }: NodeStrategyLabelProps) {
     return (
         <Dropdown hover>
             <Dropdown.Toggle button={false} className="font-mono flex items-center gap-1">
-                {/* <InformationCircleIcon className="size-4" /> */}
                 <span>{entries[0].join(' = ')}</span>
                 <EllipsisHorizontalIcon className="size-4" />
             </Dropdown.Toggle>
@@ -93,5 +90,14 @@ function NodeStrategyLabel({ strategy }: NodeStrategyLabelProps) {
                 </Table>
             </Dropdown.Menu>
         </Dropdown>
+    );
+}
+
+function NodeLink({ node }: { node: Node }) {
+    const urlObject = new URL(location.href);
+    urlObject.searchParams.set('nodes', node.alias);
+    const url = urlObject.toString();
+    return (
+        <Link href={url} target="_blank">{url}</Link>
     );
 }

--- a/web/shared/components/streams-table.tsx
+++ b/web/shared/components/streams-table.tsx
@@ -44,9 +44,7 @@ export function StreamsTable(props: StreamTableProps) {
     const tokenContext = useContext(TokenContext);
 
     useEffect(() => {
-        if (tokenContext.token.length > 0) {
-            streams.updateData();
-        }
+        streams.updateData();
     }, [tokenContext.token]);
 
     const handleViewClients = (id: string) => {

--- a/web/shared/hooks/use-refresh-timer.ts
+++ b/web/shared/hooks/use-refresh-timer.ts
@@ -1,16 +1,12 @@
 import { useCallback, useEffect, useState } from 'preact/hooks';
 
-export function useRefreshTimer<T>(initial: T, fetchData: () => Promise<T>, timeout = 3000, immediate = true) {
+export function useRefreshTimer<T>(initial: T, fetchData: () => Promise<T>, timeout = 3000) {
     const [data, setData] = useState<T>(initial);
-    const [isImmediate, _setIsImmediate] = useState(immediate);
     const [refreshTimer, setRefreshTimer] = useState(-1);
     const isRefreshing = refreshTimer > 0;
+
     const updateData = useCallback(async () => setData(await fetchData()), [fetchData]);
-    useEffect(() => {
-        if (isImmediate) {
-            updateData();
-        }
-    }, []);
+
     useEffect(() => {
         if (isRefreshing) {
             window.clearInterval(refreshTimer);
@@ -20,6 +16,7 @@ export function useRefreshTimer<T>(initial: T, fetchData: () => Promise<T>, time
             window.clearInterval(refreshTimer);
         };
     }, [updateData, timeout]);
+
     const toggleTimer = () => {
         if (isRefreshing) {
             clearInterval(refreshTimer);
@@ -29,6 +26,7 @@ export function useRefreshTimer<T>(initial: T, fetchData: () => Promise<T>, time
             setRefreshTimer(window.setInterval(updateData, timeout));
         }
     };
+
     return {
         data,
         isRefreshing,


### PR DESCRIPTION
Save token to localStorage, so sub-dashboard pages opened from liveman "Nodes" table does not require login every time.

Fixes https://github.com/binbat/live777/pull/263#issuecomment-2558529508