### PR TITLE
Fix: wrap IPv6 addresses in `tests/rtp.rs` URLs in testcase.

### DIFF
--- a/tests/rtp.rs
+++ b/tests/rtp.rs
@@ -340,14 +340,20 @@ async fn helper_livetwo_rtp(
         .unwrap()
         .to_string();
 
+    // Wrap IPv6 addresses in brackets for a valid URI host segment.
+    let ip_str = match ip {
+        std::net::IpAddr::V6(_) => format!("[{}]", ip),
+        _ => ip.to_string(),
+    };
+
     let target_url = if detect.audio.is_some() && detect.video.is_some() {
-        format!("rtp://{}?video={}&audio={}", ip, whep_port, whep_port + 2)
+        format!("rtp://{}?video={}&audio={}", ip_str, whep_port, whep_port + 2)
     } else if detect.video.is_some() {
-        format!("rtp://{}?video={}", ip, whep_port)
+        format!("rtp://{}?video={}", ip_str, whep_port)
     } else if detect.audio.is_some() {
-        format!("rtp://{}?audio={}", ip, whep_port)
+        format!("rtp://{}?audio={}", ip_str, whep_port)
     } else {
-        format!("rtp://{}", ip)
+        format!("rtp://{}", ip_str)
     };
 
     tokio::spawn(livetwo::whep::from(


### PR DESCRIPTION
IPv6 literals must be surrounded by `[` and `]` inside a URI (RFC 3986 §3.2.2).  
On Windows the tests resolve the local host to an IPv6 address, causing URL parsing to fail.

Change:
* In `helper_livetwo_rtp`, introduce `ip_str` that brackets `IpAddr::V6`.
* Replace all direct `ip` uses in the URL with `ip_str`.