### PR TITLE
chore: remove recording e2e test and playwright dependency

### DIFF
--- a/cluster.test.ts
+++ b/cluster.test.ts
@@ -8,7 +8,6 @@ import { text } from "node:stream/consumers"
 import cp, { ChildProcess } from "node:child_process"
 
 import { describe, beforeAll, afterAll, test, expect, assert, beforeEach, afterEach } from "vitest"
-import { chromium } from "@playwright/test"
 
 import { Stream } from "./web/shared/api"
 
@@ -399,71 +398,6 @@ url = "http://${localhost}:${live777CloudPort}"
 
         expect(res2).toBeTruthy()
         expect(res2?.subscribe.sessions.length).toEqual(1)
-    })
-
-    test("frontend video playback", { timeout: 60 * 1000 }, async () => {
-        const width = 320, height = 240
-        const whipintoPort = "5002"
-        using _ffmpeg = spawn([
-            "ffmpeg", "-hide_banner", "-re", "-f", "lavfi",
-            "-i", `testsrc=size=${width}x${height}:rate=30`,
-            "-vcodec", "libvpx",
-            "-f", "rtp", `rtp://127.0.0.1:${whipintoPort}`,
-            "-sdp_file", tmpFileSdpWhipinto
-        ], {
-            stderr: null,
-            onExit: e => { e.exitCode && console.log(e.stderr) },
-        })
-        using _ = rmTempFile(tmpFileSdpWhipinto)
-
-        await until(() => existsSync(tmpFileSdpWhipinto))
-
-        using _whipinto = spawn([
-            appWhipinto,
-            "-i", tmpFileSdpWhipinto,
-            "-w", `${live777VergeHost}/whip/${live777VergeStream}`,
-        ], { onExit: e => { e.exitCode && console.log(e.stderr) } })
-
-        await until(() => hasPublishStreams(live777VergeHost))
-
-        async function getRecordingMpdPath(streamId: string): Promise<string | undefined> {
-            try {
-                const res = await fetch(`${live777LivemanHost}/api/playback/${streamId}`)
-                if (!res.ok) return undefined
-                const recordings: { mpd_path: string }[] = await res.json()
-                return recordings.find(r => r.mpd_path)?.mpd_path
-            } catch {
-                return undefined
-            }
-        }
-
-        let mpdPath: string | undefined
-        await until(async () => {
-            mpdPath = await getRecordingMpdPath(live777VergeStream)
-            return mpdPath
-        })
-        assert(mpdPath, "Failed to get MPD path")
-
-        const browser = await chromium.launch()
-        const page = await browser.newPage()
-        try {
-            const playerUrl = `${live777LivemanHost}/tools/dash.html?mpd=${encodeURIComponent(mpdPath)}`
-            await page.goto(playerUrl)
-
-            await page.waitForSelector("video")
-
-            await until(async () => {
-                return await page.evaluate(() => {
-                    const video = document.querySelector("video")
-                    return video && video.currentTime > 0 && !video.paused
-                })
-            }, undefined, 1000)
-
-            const currentTime = await page.evaluate(() => document.querySelector("video")?.currentTime)
-            expect(currentTime).toBeGreaterThan(0)
-        } finally {
-            await browser.close()
-        }
     })
 
     afterAll(async () => {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "devDependencies": {
     "@biomejs/biome": "2.3.3",
     "@eslint/js": "^9.39.1",
-    "@playwright/test": "^1.56.1",
     "@preact/preset-vite": "^2.10.2",
     "@stylistic/eslint-plugin-js": "^4.4.1",
     "@types/node": "^24.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,6 @@ importers:
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.1
-      '@playwright/test':
-        specifier: ^1.56.1
-        version: 1.56.1
       '@preact/preset-vite':
         specifier: ^2.10.2
         version: 2.10.2(@babel/core@7.28.5)(preact@10.27.2)(vite@7.2.0(@types/node@24.10.0)(jiti@1.21.7)(lightningcss@1.30.2))
@@ -775,11 +772,6 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
-
-  '@playwright/test@1.56.1':
-    resolution: {integrity: sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   '@preact/preset-vite@2.10.2':
     resolution: {integrity: sha512-K9wHlJOtkE+cGqlyQ5v9kL3Ge0Ql4LlIZjkUTL+1zf3nNdF88F9UZN6VTV8jdzBX9Fl7WSzeNMSDG7qECPmSmg==}
@@ -1587,11 +1579,6 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
-    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
-    os: [darwin]
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2018,16 +2005,6 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
-
-  playwright-core@1.56.1:
-    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.56.1:
-    resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -3141,10 +3118,6 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@playwright/test@1.56.1':
-    dependencies:
-      playwright: 1.56.1
-
   '@preact/preset-vite@2.10.2(@babel/core@7.28.5)(preact@10.27.2)(vite@7.2.0(@types/node@24.10.0)(jiti@1.21.7)(lightningcss@1.30.2))':
     dependencies:
       '@babel/core': 7.28.5
@@ -4059,9 +4032,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fsevents@2.3.2:
-    optional: true
-
   fsevents@2.3.3:
     optional: true
 
@@ -4435,14 +4405,6 @@ snapshots:
   pify@2.3.0: {}
 
   pirates@4.0.7: {}
-
-  playwright-core@1.56.1: {}
-
-  playwright@1.56.1:
-    dependencies:
-      playwright-core: 1.56.1
-    optionalDependencies:
-      fsevents: 2.3.2
 
   postcss-import@15.1.0(postcss@8.5.6):
     dependencies:


### PR DESCRIPTION
Since recording is an optional feature and takes a long time, it should be placed in a separate e2e test and consider using only unit tests