### PR TITLE
feat: add H.265/HEVC support with RTP payload handling

### DIFF
--- a/liveion/src/forward/internal.rs
+++ b/liveion/src/forward/internal.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use chrono::Utc;
 use libwish::Client;
 use tokio::sync::{RwLock, broadcast};
+use tracing::trace;
 use tracing::{debug, info};
 use webrtc::api::APIBuilder;
 use webrtc::api::interceptor_registry::register_default_interceptors;
@@ -121,6 +122,11 @@ impl PeerForwardInternal {
         id: String,
         ice_candidates: Vec<RTCIceCandidateInit>,
     ) -> Result<()> {
+        trace!(
+            "Adding {} ICE candidates for session {}",
+            ice_candidates.len(),
+            id
+        );
         let publish = self.publish.read().await;
         if publish.is_some() && publish.as_ref().unwrap().id == id {
             let publish = publish.as_ref().unwrap();
@@ -206,6 +212,8 @@ impl PeerForwardInternal {
                     return;
                 }
             };
+
+            trace!("Read {} bytes from data channel", n);
             if n == 0 {
                 break;
             }

--- a/liveion/src/forward/subscribe.rs
+++ b/liveion/src/forward/subscribe.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use chrono::Utc;
 use tokio::sync::{RwLock, broadcast};
-use tracing::{debug, info};
+use tracing::{debug, info, trace};
 use webrtc::peer_connection::RTCPeerConnection;
 use webrtc::rtp_transceiver::rtp_codec::RTPCodecType;
 use webrtc::rtp_transceiver::rtp_sender::RTCRtpSender;
@@ -168,6 +168,7 @@ impl SubscribeRTCPeerConnection {
                        }
                 }
                 rtp_result = recv.recv() => {
+                    trace!("Received RTP packet, sequence: {}", sequence_number);
                     match rtp_result {
                         Ok(packet) => {
                             match track {

--- a/liveion/src/forward/track.rs
+++ b/liveion/src/forward/track.rs
@@ -66,6 +66,12 @@ impl PublishTrackRemote {
         loop {
             match track.read(&mut b).await {
                 Ok((rtp_packet, _)) => {
+                    trace!(
+                        "RTP packet - SSRC: {}, SeqNum: {}, Timestamp: {}",
+                        rtp_packet.header.ssrc,
+                        rtp_packet.header.sequence_number,
+                        rtp_packet.header.timestamp
+                    );
                     if let Err(err) = rtp_sender.send(Arc::new(rtp_packet)) {
                         debug!(
                             "[{}] [{}] [track] kind: {:?}, rid: {}, rtp broadcast error : {}",

--- a/liveion/src/stream/manager.rs
+++ b/liveion/src/stream/manager.rs
@@ -14,7 +14,7 @@ use tokio::sync::broadcast;
 use std::vec;
 use std::{collections::HashMap, sync::Arc};
 use tokio::sync::RwLock;
-use tracing::{debug, info};
+use tracing::{debug, info, trace};
 use webrtc::peer_connection::sdp::session_description::RTCSessionDescription;
 
 use crate::forward::PeerForward;
@@ -262,6 +262,10 @@ impl Manager {
     }
 
     pub async fn publish(&self, stream: String, offer: RTCSessionDescription) -> Result<Response> {
+        trace!(
+            "Publishing to stream: {}, offer type: {:?}",
+            stream, offer.sdp_type
+        );
         let mut stream_map = self.stream_map.write().await;
         let mut forward = stream_map.get(&stream).cloned();
         if forward.is_none() && self.config.auto_create_pub {
@@ -282,6 +286,11 @@ impl Manager {
         stream: String,
         offer: RTCSessionDescription,
     ) -> Result<Response> {
+        trace!(
+            "Subscribing to stream: {}, offer SDP length: {}",
+            stream,
+            offer.sdp.len()
+        );
         let mut stream_map = self.stream_map.write().await;
         let mut forward = stream_map.get(&stream).cloned();
         if forward.is_none() && self.config.auto_create_sub {

--- a/livetwo/src/payload/h265.rs
+++ b/livetwo/src/payload/h265.rs
@@ -1,17 +1,27 @@
-use tracing::trace;
+use tracing::{debug, trace, warn};
+
+const NAL_UNIT_TYPE_MASK: u8 = 0x3F;
+const START_CODE_3: [u8; 3] = [0, 0, 1];
+const START_CODE_4: [u8; 4] = [0, 0, 0, 1];
 
 mod nal_type {
     pub const H265_NAL_IDR_W_RADL: u8 = 19;
     pub const H265_NAL_IDR_N_LP: u8 = 20;
+    pub const H265_NAL_CRA_NUT: u8 = 21;
     pub const H265_NAL_VPS: u8 = 32;
     pub const H265_NAL_SPS: u8 = 33;
     pub const H265_NAL_PPS: u8 = 34;
+    pub const H265_NAL_AP: u8 = 48;
+    pub const H265_NAL_FU: u8 = 49;
 }
 
 pub struct H265Processor {
     vps: Option<Vec<u8>>,
     sps: Option<Vec<u8>>,
     pps: Option<Vec<u8>>,
+    params_injected: bool,
+    last_frame_hash: u64,
+    last_is_idr: bool,
 }
 
 impl H265Processor {
@@ -20,6 +30,9 @@ impl H265Processor {
             vps: None,
             sps: None,
             pps: None,
+            params_injected: false,
+            last_frame_hash: 0,
+            last_is_idr: false,
         }
     }
 
@@ -33,156 +46,259 @@ impl H265Processor {
         self.pps = Some(pps);
     }
 
-    pub fn is_idr_frame(&self, data: &[u8]) -> bool {
-        for i in 0..data.len().saturating_sub(4) {
-            if data[i] == 0 && data[i + 1] == 0 {
-                let nal_start = if data[i + 2] == 0 && data[i + 3] == 1 {
-                    i + 4
-                } else if data[i + 2] == 1 {
-                    i + 3
-                } else {
-                    continue;
-                };
+    pub fn is_idr_frame(&mut self, data: &[u8]) -> bool {
+        if data.is_empty() {
+            return false;
+        }
 
-                if nal_start < data.len() {
-                    let nal_type = (data[nal_start] >> 1) & 0x3F;
-                    if nal_type == nal_type::H265_NAL_IDR_W_RADL
-                        || nal_type == nal_type::H265_NAL_IDR_N_LP
-                    {
-                        return true;
-                    }
-                }
+        let hash = self.simple_hash(data);
+        if hash == self.last_frame_hash {
+            return self.last_is_idr;
+        }
+
+        trace!("Checking frame for IDR, size: {} bytes", data.len());
+
+        let is_idr = if Self::has_annex_b_start_code(data) {
+            trace!("Annex B format detected");
+            self.is_idr_frame_annex_b(data)
+        } else {
+            trace!("RTP payload format detected");
+            self.is_idr_frame_rtp(data)
+        };
+
+        self.last_frame_hash = hash;
+        self.last_is_idr = is_idr;
+
+        if is_idr {
+            debug!("IDR/keyframe detected");
+        }
+
+        is_idr
+    }
+
+    fn simple_hash(&self, data: &[u8]) -> u64 {
+        let len = data.len().min(32);
+        let mut hash: u64 = 0;
+        for &byte in data[..len].iter() {
+            hash = hash.wrapping_mul(31).wrapping_add(byte as u64);
+        }
+        hash.wrapping_add(data.len() as u64)
+    }
+
+    fn has_annex_b_start_code(data: &[u8]) -> bool {
+        data.starts_with(&START_CODE_4) || data.starts_with(&START_CODE_3)
+    }
+
+    fn is_idr_frame_annex_b(&self, data: &[u8]) -> bool {
+        for nal in NalIterator::new(data) {
+            let nal_type = (nal.data[0] >> 1) & NAL_UNIT_TYPE_MASK;
+
+            trace!(
+                "Annex B NAL type={} ({})",
+                nal_type,
+                Self::nal_type_name(nal_type)
+            );
+
+            if Self::is_idr_nal_type(nal_type) {
+                return true;
             }
         }
         false
     }
 
-    pub fn inject_params(&self, data: &[u8]) -> Vec<u8> {
-        if !self.is_idr_frame(data) {
-            return data.to_vec();
+    fn is_idr_frame_rtp(&self, data: &[u8]) -> bool {
+        if data.is_empty() {
+            return false;
         }
 
-        if self.has_params_in_data(data) {
-            trace!("Frame already has params, skipping injection");
+        let nal_type = (data[0] >> 1) & NAL_UNIT_TYPE_MASK;
+
+        trace!(
+            "RTP NAL type={} ({})",
+            nal_type,
+            Self::nal_type_name(nal_type)
+        );
+
+        match nal_type {
+            0..=47 => Self::is_idr_nal_type(nal_type),
+            nal_type::H265_NAL_AP => self.check_ap_for_idr(&data[2..]),
+            nal_type::H265_NAL_FU => {
+                if data.len() < 3 {
+                    return false;
+                }
+                let fu_header = data[2];
+                let start_bit = (fu_header >> 7) & 1;
+
+                if start_bit == 1 {
+                    let fu_nal_type = fu_header & NAL_UNIT_TYPE_MASK;
+                    trace!("FU start, NAL type={}", fu_nal_type);
+                    return Self::is_idr_nal_type(fu_nal_type);
+                }
+                false
+            }
+            _ => {
+                warn!("Unknown NAL type {}", nal_type);
+                false
+            }
+        }
+    }
+
+    fn is_idr_nal_type(nal_type: u8) -> bool {
+        matches!(
+            nal_type,
+            nal_type::H265_NAL_IDR_W_RADL
+                | nal_type::H265_NAL_IDR_N_LP
+                | nal_type::H265_NAL_CRA_NUT
+        )
+    }
+
+    fn check_ap_for_idr(&self, data: &[u8]) -> bool {
+        let mut offset = 0;
+
+        while offset + 2 < data.len() {
+            let nal_size = ((data[offset] as usize) << 8) | (data[offset + 1] as usize);
+            offset += 2;
+
+            if offset + nal_size > data.len() {
+                warn!("Invalid AP NAL size: {}", nal_size);
+                break;
+            }
+
+            if nal_size > 0 {
+                let nal_type = (data[offset] >> 1) & NAL_UNIT_TYPE_MASK;
+
+                trace!("AP NAL type={}, size={}", nal_type, nal_size);
+
+                if Self::is_idr_nal_type(nal_type) {
+                    return true;
+                }
+            }
+
+            offset += nal_size;
+        }
+
+        false
+    }
+
+    pub fn inject_params(&mut self, data: &[u8]) -> Vec<u8> {
+        let is_idr = self.is_idr_frame(data);
+
+        if !is_idr && self.params_injected {
+            trace!("Not IDR and params already injected, skipping");
             return data.to_vec();
         }
 
         if !self.has_params() {
-            trace!("No cached H.265 VPS/SPS/PPS");
+            warn!("No cached params available for injection");
             return data.to_vec();
         }
 
-        let mut result = Vec::new();
-        result.extend_from_slice(&[0, 0, 0, 1]);
-        result.extend_from_slice(self.vps.as_ref().unwrap());
-        result.extend_from_slice(&[0, 0, 0, 1]);
-        result.extend_from_slice(self.sps.as_ref().unwrap());
-        result.extend_from_slice(&[0, 0, 0, 1]);
-        result.extend_from_slice(self.pps.as_ref().unwrap());
+        debug!(
+            "Injecting VPS/SPS/PPS (is_idr={}, first_injection={})",
+            is_idr, !self.params_injected
+        );
+
+        let mut result = Vec::with_capacity(
+            4 + self.vps.as_ref().map_or(0, |v| v.len())
+                + 4
+                + self.sps.as_ref().map_or(0, |v| v.len())
+                + 4
+                + self.pps.as_ref().map_or(0, |v| v.len())
+                + data.len(),
+        );
+
+        if let Some(ref vps) = self.vps {
+            result.extend_from_slice(&START_CODE_4);
+            result.extend_from_slice(vps);
+            trace!("Injected VPS ({} bytes)", vps.len());
+        }
+
+        if let Some(ref sps) = self.sps {
+            result.extend_from_slice(&START_CODE_4);
+            result.extend_from_slice(sps);
+            trace!("Injected SPS ({} bytes)", sps.len());
+        }
+
+        if let Some(ref pps) = self.pps {
+            result.extend_from_slice(&START_CODE_4);
+            result.extend_from_slice(pps);
+            trace!("Injected PPS ({} bytes)", pps.len());
+        }
+
+        if !Self::has_annex_b_start_code(data) && !data.is_empty() {
+            result.extend_from_slice(&START_CODE_4);
+        }
+
         result.extend_from_slice(data);
 
-        trace!("Injected H.265 VPS/SPS/PPS");
+        self.params_injected = true;
+
         result
     }
 
     pub fn extract_params(&mut self, data: &[u8]) {
-        let mut i = 0;
-        while i + 4 < data.len() {
-            if data[i] == 0 && data[i + 1] == 0 {
-                let nal_start = if data[i + 2] == 0 && data[i + 3] == 1 {
-                    i + 4
-                } else if data[i + 2] == 1 {
-                    i + 3
-                } else {
-                    i += 1;
-                    continue;
-                };
+        let mut extracted_count = 0;
 
-                if nal_start >= data.len() {
-                    break;
+        for nal in NalIterator::new(data) {
+            let nal_type = (nal.data[0] >> 1) & NAL_UNIT_TYPE_MASK;
+
+            match nal_type {
+                nal_type::H265_NAL_VPS if self.vps.is_none() => {
+                    self.vps = Some(nal.data.to_vec());
+                    trace!("Extracted VPS: {} bytes", nal.data.len());
+                    extracted_count += 1;
                 }
-
-                let nal_type = (data[nal_start] >> 1) & 0x3F;
-
-                let mut nal_end = nal_start + 1;
-                while nal_end + 3 < data.len() {
-                    if (data[nal_end] == 0 && data[nal_end + 1] == 0 && data[nal_end + 2] == 1)
-                        || (data[nal_end] == 0
-                            && data[nal_end + 1] == 0
-                            && data[nal_end + 2] == 0
-                            && data[nal_end + 3] == 1)
-                    {
-                        break;
-                    }
-                    nal_end += 1;
+                nal_type::H265_NAL_SPS if self.sps.is_none() => {
+                    self.sps = Some(nal.data.to_vec());
+                    trace!("Extracted SPS: {} bytes", nal.data.len());
+                    extracted_count += 1;
                 }
-                if nal_end >= data.len() - 3 {
-                    nal_end = data.len();
+                nal_type::H265_NAL_PPS if self.pps.is_none() => {
+                    self.pps = Some(nal.data.to_vec());
+                    trace!("Extracted PPS: {} bytes", nal.data.len());
+                    extracted_count += 1;
                 }
-
-                match nal_type {
-                    nal_type::H265_NAL_VPS => {
-                        if self.vps.is_none() {
-                            self.vps = Some(data[nal_start..nal_end].to_vec());
-                            trace!("Extracted VPS: {} bytes", nal_end - nal_start);
-                        }
-                    }
-                    nal_type::H265_NAL_SPS => {
-                        if self.sps.is_none() {
-                            self.sps = Some(data[nal_start..nal_end].to_vec());
-                            trace!("Extracted SPS: {} bytes", nal_end - nal_start);
-                        }
-                    }
-                    nal_type::H265_NAL_PPS => {
-                        if self.pps.is_none() {
-                            self.pps = Some(data[nal_start..nal_end].to_vec());
-                            trace!("Extracted PPS: {} bytes", nal_end - nal_start);
-                        }
-                    }
-                    _ => {}
-                }
-
-                i = nal_end;
-            } else {
-                i += 1;
+                _ => {}
             }
+
+            if self.has_params() {
+                break;
+            }
+        }
+
+        if extracted_count > 0 {
+            debug!("Extracted {} parameter sets", extracted_count);
         }
     }
 
-    fn has_params_in_data(&self, data: &[u8]) -> bool {
-        let mut has_vps = false;
-        let mut has_sps = false;
-        let mut has_pps = false;
-
-        let check_len = data.len().min(2048);
-
-        for i in 0..check_len.saturating_sub(4) {
-            if data[i] == 0 && data[i + 1] == 0 {
-                let nal_start = if data[i + 2] == 0 && data[i + 3] == 1 {
-                    i + 4
-                } else if data[i + 2] == 1 {
-                    i + 3
-                } else {
-                    continue;
-                };
-
-                if nal_start < check_len {
-                    let nal_type = (data[nal_start] >> 1) & 0x3F;
-                    match nal_type {
-                        nal_type::H265_NAL_VPS => has_vps = true,
-                        nal_type::H265_NAL_SPS => has_sps = true,
-                        nal_type::H265_NAL_PPS => has_pps = true,
-                        _ => {}
-                    }
-
-                    if has_vps && has_sps && has_pps {
-                        return true;
-                    }
-                }
-            }
+    fn nal_type_name(nal_type: u8) -> &'static str {
+        match nal_type {
+            0 => "TRAIL_N",
+            1 => "TRAIL_R",
+            2 => "TSA_N",
+            3 => "TSA_R",
+            4 => "STSA_N",
+            5 => "STSA_R",
+            6 => "RADL_N",
+            7 => "RADL_R",
+            8 => "RASL_N",
+            9 => "RASL_R",
+            16 => "BLA_W_LP",
+            17 => "BLA_W_RADL",
+            18 => "BLA_N_LP",
+            19 => "IDR_W_RADL",
+            20 => "IDR_N_LP",
+            21 => "CRA_NUT",
+            32 => "VPS",
+            33 => "SPS",
+            34 => "PPS",
+            35 => "AUD",
+            39 => "PREFIX_SEI",
+            40 => "SUFFIX_SEI",
+            48 => "AP",
+            49 => "FU",
+            _ => "OTHER",
         }
-
-        has_vps && has_sps && has_pps
     }
 }
 
@@ -190,4 +306,73 @@ impl Default for H265Processor {
     fn default() -> Self {
         Self::new()
     }
+}
+
+struct NalIterator<'a> {
+    data: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> NalIterator<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { data, offset: 0 }
+    }
+
+    fn extract_nal_unit(&mut self, nal_start: usize) -> Option<NalUnit<'a>> {
+        if nal_start >= self.data.len() {
+            return None;
+        }
+
+        let mut nal_end = nal_start + 1;
+        while nal_end + 3 < self.data.len() {
+            if self.data[nal_end..].starts_with(&START_CODE_4)
+                || self.data[nal_end..].starts_with(&START_CODE_3)
+            {
+                break;
+            }
+            nal_end += 1;
+        }
+
+        if nal_end >= self.data.len() - 3 {
+            nal_end = self.data.len();
+        }
+
+        self.offset = nal_end;
+
+        Some(NalUnit {
+            data: &self.data[nal_start..nal_end],
+        })
+    }
+}
+
+impl<'a> Iterator for NalIterator<'a> {
+    type Item = NalUnit<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.offset + 4 <= self.data.len() {
+            let remaining = &self.data[self.offset..];
+
+            // Check for 4-byte start code (0x00 0x00 0x00 0x01)
+            if remaining.starts_with(&START_CODE_4) {
+                let nal_start = self.offset + 4;
+                self.offset = nal_start;
+                return self.extract_nal_unit(nal_start);
+            }
+
+            // Check for 3-byte start code (0x00 0x00 0x01)
+            if remaining.starts_with(&START_CODE_3) {
+                let nal_start = self.offset + 3;
+                self.offset = nal_start;
+                return self.extract_nal_unit(nal_start);
+            }
+
+            self.offset += 1;
+        }
+
+        None
+    }
+}
+
+struct NalUnit<'a> {
+    data: &'a [u8],
 }

--- a/livetwo/src/payload/repayload.rs
+++ b/livetwo/src/payload/repayload.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use tracing::{error, trace};
+use tracing::{debug, error, trace, warn};
 use webrtc::{
     api::media_engine::*,
     rtp::{
@@ -11,6 +11,16 @@ use webrtc::{
 
 use super::{H264Processor, H265Processor};
 use crate::payload::RTP_OUTBOUND_MTU;
+
+const NAL_UNIT_TYPE_MASK: u8 = 0x3F;
+const FU_START_BITMASK: u8 = 0x80;
+const FU_END_BITMASK: u8 = 0x40;
+
+const START_CODE_3: [u8; 3] = [0, 0, 1];
+const START_CODE_4: [u8; 4] = [0, 0, 0, 1];
+
+const H265_NAL_TYPE_FU: u8 = 49;
+const H265_NAL_TYPE_AP: u8 = 48;
 
 pub trait RePayload {
     fn payload(&mut self, packet: Packet) -> Vec<Packet>;
@@ -140,6 +150,199 @@ impl RePayloadCodec {
             frame_count: 0,
         }
     }
+
+    fn convert_h265_to_annex_b(&self, data: &[u8]) -> Vec<u8> {
+        if data.is_empty() {
+            return Vec::new();
+        }
+
+        let first_byte = data[0];
+        let nal_type = (first_byte >> 1) & NAL_UNIT_TYPE_MASK;
+
+        debug!("H.265 NAL type: {}", nal_type);
+
+        if nal_type <= 31 {
+            debug!("Converting single NAL to Annex B");
+            let mut result = Vec::with_capacity(4 + data.len());
+            result.extend_from_slice(&START_CODE_4);
+            result.extend_from_slice(data);
+            return result;
+        }
+
+        if nal_type == H265_NAL_TYPE_AP && data.len() > 2 {
+            debug!("Converting AP to Annex B");
+            return self.convert_h265_ap_to_annex_b(&data[2..]);
+        }
+
+        if nal_type == H265_NAL_TYPE_FU {
+            error!("FU should not reach convert_h265_to_annex_b!");
+        }
+
+        warn!("Unknown H.265 NAL type {}, adding start code", nal_type);
+        let mut result = Vec::with_capacity(4 + data.len());
+        result.extend_from_slice(&START_CODE_4);
+        result.extend_from_slice(data);
+        result
+    }
+
+    fn convert_h265_ap_to_annex_b(&self, data: &[u8]) -> Vec<u8> {
+        let mut result = Vec::new();
+        let mut offset = 0;
+        let mut nal_count = 0;
+
+        while offset + 2 <= data.len() {
+            let nal_size = ((data[offset] as usize) << 8) | (data[offset + 1] as usize);
+            offset += 2;
+
+            if nal_size == 0 || offset + nal_size > data.len() {
+                warn!("Invalid AP NAL size: {}", nal_size);
+                break;
+            }
+
+            nal_count += 1;
+            result.extend_from_slice(&START_CODE_4);
+            result.extend_from_slice(&data[offset..offset + nal_size]);
+            debug!("Converted AP NAL #{}: {} bytes", nal_count, nal_size);
+
+            offset += nal_size;
+        }
+
+        debug!(
+            "Converted {} NAL units from AP, total {} bytes",
+            nal_count,
+            result.len()
+        );
+        result
+    }
+
+    fn payload_h265_manually(
+        &mut self,
+        data: &[u8],
+        original_header: &webrtc::rtp::header::Header,
+    ) -> Vec<Packet> {
+        const MAX_PAYLOAD_SIZE: usize = RTP_OUTBOUND_MTU - 12;
+
+        let mut packets = Vec::new();
+        let mut offset = 0;
+
+        while offset < data.len() {
+            if offset + 4 > data.len() {
+                break;
+            }
+
+            let start_code_len = if data[offset..].starts_with(&START_CODE_4) {
+                4
+            } else if data[offset..].starts_with(&START_CODE_3) {
+                3
+            } else {
+                offset += 1;
+                continue;
+            };
+
+            let nal_start = offset + start_code_len;
+
+            let mut nal_end = nal_start + 1;
+            while nal_end + 3 < data.len() {
+                if data[nal_end..].starts_with(&START_CODE_4)
+                    || data[nal_end..].starts_with(&START_CODE_3)
+                {
+                    break;
+                }
+                nal_end += 1;
+            }
+            if nal_end >= data.len() - 3 {
+                nal_end = data.len();
+            }
+
+            let nal_unit = &data[nal_start..nal_end];
+
+            if nal_unit.len() < 2 {
+                offset = nal_end;
+                continue;
+            }
+
+            let nal_header = &nal_unit[0..2];
+            let nal_type = (nal_header[0] >> 1) & NAL_UNIT_TYPE_MASK;
+
+            debug!(
+                "H.265 NAL unit - type={}, size={} bytes",
+                nal_type,
+                nal_unit.len()
+            );
+
+            // If NAL unit fits in MTU, send as Single NAL Unit
+            if nal_unit.len() <= MAX_PAYLOAD_SIZE {
+                let mut header = original_header.clone();
+                header.sequence_number = self.base.sequence_number;
+                header.marker = nal_end >= data.len();
+                self.base.sequence_number = self.base.sequence_number.wrapping_add(1);
+
+                let marker = header.marker;
+
+                packets.push(Packet {
+                    header,
+                    payload: Bytes::from(nal_unit.to_vec()),
+                });
+
+                debug!(
+                    "H.265 Single NAL - type={}, size={}, marker={}",
+                    nal_type,
+                    nal_unit.len(),
+                    marker
+                );
+            } else {
+                // NAL unit too large, fragment using FU
+                let fu_payload_data = &nal_unit[2..];
+                let mut fu_offset = 0;
+                let mut is_first = true;
+
+                while fu_offset < fu_payload_data.len() {
+                    let chunk_size = (fu_payload_data.len() - fu_offset).min(MAX_PAYLOAD_SIZE - 3);
+                    let is_last = fu_offset + chunk_size >= fu_payload_data.len();
+
+                    let mut fu_header = nal_type;
+                    if is_first {
+                        fu_header |= FU_START_BITMASK;
+                    }
+                    if is_last {
+                        fu_header |= FU_END_BITMASK;
+                    }
+
+                    let mut fu_packet = Vec::with_capacity(3 + chunk_size);
+                    fu_packet.push((nal_header[0] & 0x81) | (H265_NAL_TYPE_FU << 1));
+                    fu_packet.push(nal_header[1]);
+                    fu_packet.push(fu_header);
+                    fu_packet
+                        .extend_from_slice(&fu_payload_data[fu_offset..fu_offset + chunk_size]);
+
+                    let mut header = original_header.clone();
+                    header.sequence_number = self.base.sequence_number;
+                    header.marker = is_last && nal_end >= data.len();
+                    self.base.sequence_number = self.base.sequence_number.wrapping_add(1);
+
+                    let marker = header.marker;
+
+                    packets.push(Packet {
+                        header,
+                        payload: Bytes::from(fu_packet),
+                    });
+
+                    debug!(
+                        "H.265 FU - type={}, S={}, E={}, size={}, marker={}",
+                        nal_type, is_first, is_last, chunk_size, marker
+                    );
+
+                    fu_offset += chunk_size;
+                    is_first = false;
+                }
+            }
+
+            offset = nal_end;
+        }
+
+        debug!("Generated {} H.265 RTP packets", packets.len());
+        packets
+    }
 }
 
 impl RePayload for RePayloadCodec {
@@ -148,55 +351,125 @@ impl RePayload for RePayloadCodec {
 
         match self.decoder.depacketize(&packet.payload) {
             Ok(data) => {
-                if let Some(ref mut processor) = self.h264_processor
-                    && !processor.has_params()
-                {
-                    processor.extract_params(&data);
-                }
-                if let Some(ref mut processor) = self.h265_processor
-                    && !processor.has_params()
-                {
-                    processor.extract_params(&data);
-                }
+                debug!("Depacketized {} bytes", data.len());
 
-                self.base.buffer.push(data);
+                if data.len() >= 3 {
+                    let has_start_code =
+                        data.starts_with(&START_CODE_4) || data.starts_with(&START_CODE_3);
+
+                    debug!(
+                        "First 4 bytes: {:02X?}, has_start_code: {}",
+                        &data[..4.min(data.len())],
+                        has_start_code
+                    );
+
+                    if !has_start_code && self.h265_processor.is_some() {
+                        let nal_type = (data[0] >> 1) & NAL_UNIT_TYPE_MASK;
+
+                        if nal_type == H265_NAL_TYPE_FU && data.len() >= 3 {
+                            let fu_header = data[2];
+                            let start_bit = (fu_header & FU_START_BITMASK) != 0;
+                            let end_bit = (fu_header & FU_END_BITMASK) != 0;
+                            let fu_type = fu_header & NAL_UNIT_TYPE_MASK;
+
+                            debug!(
+                                "FU packet - S={}, E={}, type={}",
+                                start_bit, end_bit, fu_type
+                            );
+
+                            if start_bit {
+                                let reconstructed_byte0 = (data[0] & 0x81) | (fu_type << 1);
+                                let mut result = Vec::with_capacity(6 + data.len() - 3);
+                                result.extend_from_slice(&START_CODE_4);
+                                result.push(reconstructed_byte0);
+                                result.push(data[1]);
+                                result.extend_from_slice(&data[3..]);
+                                self.base.buffer.push(Bytes::from(result));
+                                debug!("FU start - added start code and NAL header");
+                            } else {
+                                self.base.buffer.push(Bytes::from(data[3..].to_vec()));
+                                debug!("FU continuation - added payload only");
+                            }
+                        } else {
+                            debug!("Converting non-FU H.265 to Annex B");
+                            let converted = Bytes::from(self.convert_h265_to_annex_b(&data));
+                            self.base.buffer.push(converted);
+                        }
+                    } else {
+                        self.base.buffer.push(data);
+                    }
+                } else {
+                    self.base.buffer.push(data);
+                }
             }
             Err(e) => {
                 error!("Depacketize error: {}", e);
+                return vec![];
             }
         }
 
         if packet.header.marker {
             self.frame_count += 1;
-
             let combined_data = Bytes::from(self.base.buffer.concat());
 
-            let data_with_params = if let Some(ref processor) = self.h264_processor {
+            if combined_data.is_empty() {
+                warn!("Empty frame data, skipping");
+                self.base.clear_buffer();
+                return vec![];
+            }
+            let data_with_params = if let Some(ref mut processor) = self.h264_processor {
+                if !processor.has_params() {
+                    processor.extract_params(&combined_data);
+                }
                 Bytes::from(processor.inject_params(&combined_data))
-            } else if let Some(ref processor) = self.h265_processor {
+            } else if let Some(ref mut processor) = self.h265_processor {
+                if !processor.has_params() {
+                    processor.extract_params(&combined_data);
+                }
                 Bytes::from(processor.inject_params(&combined_data))
             } else {
+                combined_data.clone()
+            };
+
+            debug!(
+                "Data after param injection: {} bytes (diff: {})",
+                data_with_params.len(),
+                data_with_params.len() as i64 - combined_data.len() as i64
+            );
+
+            let final_data = if data_with_params.len() > combined_data.len() {
+                debug!("Sending frame with injected params");
+                data_with_params
+            } else {
+                debug!("Sending frame without params (frame #{})", self.frame_count);
                 combined_data
             };
 
-            let packets = match self.encoder.payload(RTP_OUTBOUND_MTU, &data_with_params) {
-                Ok(payloads) => {
-                    let length = payloads.len();
-                    payloads
-                        .into_iter()
-                        .enumerate()
-                        .map(|(i, payload)| {
-                            let mut header = packet.header.clone();
-                            header.sequence_number = self.base.sequence_number;
-                            header.marker = i == length - 1;
-                            self.base.sequence_number = self.base.sequence_number.wrapping_add(1);
-                            Packet { header, payload }
-                        })
-                        .collect::<Vec<Packet>>()
-                }
-                Err(e) => {
-                    error!("Payload error: {}", e);
-                    vec![]
+            let packets = if self.h265_processor.is_some() {
+                self.payload_h265_manually(&final_data, &packet.header)
+            } else {
+                match self.encoder.payload(RTP_OUTBOUND_MTU, &final_data) {
+                    Ok(payloads) => {
+                        let length = payloads.len();
+                        debug!("Generated {} output packets", length);
+
+                        payloads
+                            .into_iter()
+                            .enumerate()
+                            .map(|(i, payload)| {
+                                let mut header = packet.header.clone();
+                                header.sequence_number = self.base.sequence_number;
+                                header.marker = i == length - 1;
+                                self.base.sequence_number =
+                                    self.base.sequence_number.wrapping_add(1);
+                                Packet { header, payload }
+                            })
+                            .collect::<Vec<Packet>>()
+                    }
+                    Err(e) => {
+                        error!("Payload error: {}", e);
+                        vec![]
+                    }
                 }
             };
 

--- a/tests/rtp.rs
+++ b/tests/rtp.rs
@@ -124,6 +124,33 @@ async fn test_livetwo_rtp_h264() {
 }
 
 #[tokio::test]
+async fn test_livetwo_rtp_h265() {
+    let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
+    let port = 0;
+
+    let whip_port: u16 = 5090;
+    let whep_port: u16 = 5095;
+
+    let width = 640;
+    let height = 480;
+    let codec = "-vcodec libx265 -preset ultrafast -tune zerolatency -x265-params keyint=30:min-keyint=30:bframes=0:repeat-headers=1 -pix_fmt yuv420p -b:v 1000k -minrate 1000k -maxrate 1000k -bufsize 1000k";
+    let prefix = format!("ffmpeg -re -f lavfi -i testsrc=size={width}x{height}:rate=30 {codec}");
+
+    helper_livetwo_rtp(
+        ip,
+        port,
+        &prefix,
+        whip_port,
+        whep_port,
+        Detect {
+            audio: None,
+            video: Some((width, height)),
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
 async fn test_livetwo_rtp_vp9_4k() {
     let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
     let port = 0;

--- a/tests/rtsp.rs
+++ b/tests/rtsp.rs
@@ -83,6 +83,63 @@ async fn test_livetwo_rtsp_h264_tcp() {
     )
     .await;
 }
+#[tokio::test]
+async fn test_livetwo_rtsp_h265_udp() {
+    let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
+    let port = 0;
+
+    let whip_port: u16 = 8670;
+    let whep_port: u16 = 8675;
+
+    let width = 640;
+    let height = 480;
+    let prefix = format!(
+        "ffmpeg -re -f lavfi -i testsrc=size={width}x{height}:rate=30 -vcodec libx265 -preset ultrafast -tune zerolatency -x265-params keyint=15:min-keyint=15:bframes=0:repeat-headers=1 -pix_fmt yuv420p -b:v 1000k -minrate 1000k -maxrate 1000k -bufsize 1000k"
+    );
+
+    helper_livetwo_rtsp(
+        ip,
+        port,
+        &prefix,
+        whip_port,
+        whep_port,
+        Detect {
+            audio: None,
+            video: Some((width, height)),
+        },
+        Transport::Udp,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_livetwo_rtsp_h265_tcp() {
+    let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
+    let port = 0;
+
+    let whip_port: u16 = 8680;
+    let whep_port: u16 = 8685;
+
+    let width = 640;
+    let height = 480;
+    let prefix = format!(
+        "ffmpeg -re -f lavfi -i testsrc=size={width}x{height}:rate=30 -vcodec libx265 -preset ultrafast -tune zerolatency -x265-params keyint=15:min-keyint=15:bframes=0:repeat-headers=1 -pix_fmt yuv420p -b:v 1000k -minrate 1000k -maxrate 1000k -bufsize 1000k -rtsp_transport tcp"
+    );
+
+    helper_livetwo_rtsp(
+        ip,
+        port,
+        &prefix,
+        whip_port,
+        whep_port,
+        Detect {
+            audio: None,
+            video: Some((width, height)),
+        },
+        Transport::Tcp,
+    )
+    .await;
+}
 
 #[tokio::test]
 async fn test_livetwo_rtsp_vp8_udp() {


### PR DESCRIPTION
- Implement H265Processor with IDR detection and parameter injection
- Add RTP FU/AP packet handling and Annex B conversion
- Improve SDP parameter extraction with better error handling
- Add comprehensive test coverage (RTP, RTSP, RTSP cycle)
- Add trace-level logging for RTP packet flow
- Support both UDP and TCP transport modes