### PR TITLE
feat: add QR latency frame rate controls

### DIFF
--- a/web/debugger/components/player.tsx
+++ b/web/debugger/components/player.tsx
@@ -14,24 +14,90 @@ export default function Player(props: {
     stream: MediaStream;
     onVideoElement?: (video: HTMLVideoElement) => void;
     getPeerConnection?: () => RTCPeerConnection | null;
+    showRenderFps?: boolean;
 }) {
     const [resolution, setResolution] = createSignal("");
+    const [renderFps, setRenderFps] = createSignal<number | null>(null);
     const [displayWidth, setDisplayWidth] = createSignal("320px");
 
     let ref: HTMLVideoElement | undefined;
+    let renderFpsCallbackId: number | null = null;
+    let renderFpsToken = 0;
+    let windowPresentedFrames: number | null = null;
+    let windowStartedAt: DOMHighResTimeStamp | null = null;
+    let lastFrameTime: DOMHighResTimeStamp | null = null;
+    let staleTimer: ReturnType<typeof setInterval> | null = null;
 
     const handleResize = () => {
         if (!ref) return;
         setResolution(`${ref.videoWidth}x${ref.videoHeight}`);
     };
 
+    const stopRenderFps = () => {
+        renderFpsToken += 1;
+        if (ref && renderFpsCallbackId !== null) {
+            ref.cancelVideoFrameCallback(renderFpsCallbackId);
+        }
+        renderFpsCallbackId = null;
+        windowPresentedFrames = null;
+        windowStartedAt = null;
+        lastFrameTime = null;
+        if (staleTimer) {
+            clearInterval(staleTimer);
+            staleTimer = null;
+        }
+        setRenderFps(null);
+    };
+
+    const startRenderFps = () => {
+        if (!ref || !props.showRenderFps) return;
+        stopRenderFps();
+        const video = ref;
+        const token = renderFpsToken;
+
+        const onFrame: VideoFrameRequestCallback = (now, metadata) => {
+            if (token !== renderFpsToken) return;
+            if (windowPresentedFrames === null || windowStartedAt === null) {
+                windowPresentedFrames = metadata.presentedFrames;
+                windowStartedAt = now;
+            } else if (
+                metadata.presentedFrames > windowPresentedFrames &&
+                now - windowStartedAt >= 1000
+            ) {
+                const frameCount =
+                    metadata.presentedFrames - windowPresentedFrames;
+                setRenderFps((frameCount * 1000) / (now - windowStartedAt));
+                windowPresentedFrames = metadata.presentedFrames;
+                windowStartedAt = now;
+            }
+            lastFrameTime = now;
+            renderFpsCallbackId = video.requestVideoFrameCallback(onFrame);
+        };
+
+        renderFpsCallbackId = video.requestVideoFrameCallback(onFrame);
+        staleTimer = setInterval(() => {
+            if (
+                lastFrameTime !== null &&
+                performance.now() - lastFrameTime > 2000
+            ) {
+                windowPresentedFrames = null;
+                windowStartedAt = null;
+                setRenderFps(null);
+            }
+        }, 1000);
+    };
+
     onCleanup(() => {
+        stopRenderFps();
         ref?.removeEventListener("resize", handleResize);
     });
 
     return (
         <>
-            <h5>Raw Resolution: {resolution()}</h5>
+            <h5>
+                Raw Resolution: {resolution()}
+                {props.showRenderFps && `@${renderFps()?.toFixed(1) ?? "--"}`}
+            </h5>
             <label>
                 Video Width:
                 <select
@@ -54,11 +120,13 @@ export default function Player(props: {
                     controls
                     onVideoElement={(video) => {
                         if (ref === video) return;
+                        stopRenderFps();
                         ref?.removeEventListener("resize", handleResize);
                         ref = video;
                         props.onVideoElement?.(video);
                         video.addEventListener("resize", handleResize);
                         handleResize();
+                        startRenderFps();
                     }}
                     getPeerConnection={props.getPeerConnection}
                 />

--- a/web/debugger/components/publish.ts
+++ b/web/debugger/components/publish.ts
@@ -44,6 +44,7 @@ type startWhipConfig = {
     };
     onStream: (stream: MediaStream | null) => void;
     onChannel: (channel: RTCDataChannel) => void;
+    onPeerConnection?: (peerConnection: RTCPeerConnection | null) => void;
     log: (msg: string) => void;
 };
 
@@ -77,6 +78,7 @@ export default async function startWhip(
     cfg.onStream(stream);
 
     const pc = new RTCPeerConnection();
+    cfg.onPeerConnection?.(pc);
 
     // NOTE:
     // 1. Live777 Don't support label
@@ -135,6 +137,7 @@ export default async function startWhip(
     const stop = async () => {
         await whip.stop();
         cfg.log("stopped");
+        cfg.onPeerConnection?.(null);
         stream.getTracks().map((track) => track.stop());
         cfg.onStream(null);
     };

--- a/web/debugger/components/publisher.tsx
+++ b/web/debugger/components/publisher.tsx
@@ -1,6 +1,11 @@
 import { useSearchParams } from "@solidjs/router";
 import { createSignal, onCleanup, Show } from "solid-js";
-import { QRCodeStream } from "../../shared/qrcode-stream";
+import {
+    DefaultQRCodeFrameRate,
+    type QRCodeFrameRate,
+    QRCodeFrameRates,
+    QRCodeStream,
+} from "../../shared/qrcode-stream";
 import { createLogger } from "../primitive/logger";
 import Datachannel from "./datachannel";
 import Device from "./device";
@@ -82,6 +87,8 @@ export default function Publisher() {
     const [selectVideoHeight, setSelectVideoHeight] = createSignal("");
     const [selectAudioPseudo, setSelectAudioPseudo] = createSignal(false);
     const [selectVideoLayer, setSelectVideoLayer] = createSignal("f");
+    const [selectQrFrameRate, setSelectQrFrameRate] =
+        createSignal<QRCodeFrameRate>(DefaultQRCodeFrameRate);
 
     const [audioTrackCount, setAudioTrackCount] = createSignal(0);
     const [videoTrackCount, setVideoTrackCount] = createSignal(0);
@@ -166,7 +173,7 @@ export default function Publisher() {
         qrCanvasRef.width = QrCanvasWidth;
         qrCanvasRef.height = QrCanvasHeight;
         if (!qrStream) {
-            qrStream = new QRCodeStream(qrCanvasRef);
+            qrStream = new QRCodeStream(qrCanvasRef, selectQrFrameRate());
         }
         return qrStream.capture();
     };
@@ -333,6 +340,24 @@ export default function Publisher() {
 
     const useQrTimeSource = () => {
         prepareQrStream();
+    };
+
+    const updateQrFrameRate = (frameRate: QRCodeFrameRate) => {
+        setSelectQrFrameRate(frameRate);
+        if (sourceMode() !== "qrtime" || qrState() !== "previewing") {
+            return;
+        }
+
+        clearQrStream();
+        const inputStream = ensureQrInputStream();
+        if (!inputStream) {
+            setLogs("QRCode Time stream initialization failed.");
+            return;
+        }
+
+        updatePreviewStream(inputStream);
+        setQrState("previewing");
+        setLogs(`QR source updated to ${frameRate} fps.`);
     };
 
     return (
@@ -502,6 +527,28 @@ export default function Publisher() {
                     </section>
                 </Show>
                 <Show when={sourceMode() === "qrtime" && !disabled()}>
+                    <section>
+                        <label>
+                            QR Frame Rate:
+                            <select
+                                value={selectQrFrameRate()}
+                                onChange={(e) => {
+                                    updateQrFrameRate(
+                                        Number.parseInt(
+                                            e.currentTarget.value,
+                                            10,
+                                        ) as QRCodeFrameRate,
+                                    );
+                                }}
+                            >
+                                {QRCodeFrameRates.map((frameRate) => (
+                                    <option value={frameRate}>
+                                        {frameRate} fps
+                                    </option>
+                                ))}
+                            </select>
+                        </label>
+                    </section>
                     <section>
                         <small>
                             {qrState() === "previewing"

--- a/web/debugger/components/publisher.tsx
+++ b/web/debugger/components/publisher.tsx
@@ -1,7 +1,11 @@
 import { useSearchParams } from "@solidjs/router";
-import { createSignal, onCleanup, Show } from "solid-js";
+import { createEffect, createSignal, onCleanup, Show } from "solid-js";
 import {
-    DefaultQRCodeFrameRate,
+    collectVideoRtpFps,
+    type VideoFpsSamples,
+} from "../../player-core/webrtc-stats";
+import {
+    parseQRCodeFrameRate,
     type QRCodeFrameRate,
     QRCodeFrameRates,
     QRCodeStream,
@@ -70,7 +74,13 @@ type QrState = "idle" | "previewing" | "publishing";
 const QrCanvasWidth = 480;
 const QrCanvasHeight = 320;
 
+function formatFps(fps: number | null) {
+    return fps === null ? "--" : fps.toFixed(1);
+}
+
 export default function Publisher() {
+    const [searchParams, setSearchParams] = useSearchParams();
+
     const [disabled, setDisabled] = createSignal(false);
     const [stream, setStream] = createSignal<MediaStream | null>(null);
     const [preparedDesktopStream, setPreparedDesktopStream] =
@@ -88,12 +98,11 @@ export default function Publisher() {
     const [selectAudioPseudo, setSelectAudioPseudo] = createSignal(false);
     const [selectVideoLayer, setSelectVideoLayer] = createSignal("f");
     const [selectQrFrameRate, setSelectQrFrameRate] =
-        createSignal<QRCodeFrameRate>(DefaultQRCodeFrameRate);
+        createSignal<QRCodeFrameRate>(parseQRCodeFrameRate(searchParams.qrfps));
+    const [actualSendFps, setActualSendFps] = createSignal<number | null>(null);
 
     const [audioTrackCount, setAudioTrackCount] = createSignal(0);
     const [videoTrackCount, setVideoTrackCount] = createSignal(0);
-
-    const [searchParams, setSearchParams] = useSearchParams();
 
     const [logs, setLogs, clear] = createLogger();
 
@@ -101,6 +110,10 @@ export default function Publisher() {
     let qrCanvasRef: HTMLCanvasElement | undefined;
     let qrStream: QRCodeStream | null = null;
     let desktopStreamCleanupInProgress = false;
+    let publisherPeerConnection: RTCPeerConnection | null = null;
+    let sendFpsSamples: VideoFpsSamples = {};
+    let sendFpsInterval: ReturnType<typeof setInterval> | null = null;
+    let sendFpsToken = 0;
 
     const selectedVideoCodec = () => (searchParams.vcodec as string) || "";
 
@@ -157,7 +170,47 @@ export default function Publisher() {
         }
     };
 
+    const stopActualSendFps = () => {
+        sendFpsToken += 1;
+        if (sendFpsInterval) {
+            clearInterval(sendFpsInterval);
+            sendFpsInterval = null;
+        }
+        publisherPeerConnection = null;
+        sendFpsSamples = {};
+        setActualSendFps(null);
+    };
+
+    const startActualSendFps = (peerConnection: RTCPeerConnection) => {
+        stopActualSendFps();
+        publisherPeerConnection = peerConnection;
+        const token = sendFpsToken;
+
+        const syncActualSendFps = async () => {
+            const currentPeerConnection = publisherPeerConnection;
+            if (!currentPeerConnection) {
+                return;
+            }
+            const stats = await collectVideoRtpFps(
+                currentPeerConnection,
+                "outbound",
+                sendFpsSamples,
+            );
+            if (token !== sendFpsToken) {
+                return;
+            }
+            sendFpsSamples = stats.samples;
+            setActualSendFps(stats.fps);
+        };
+
+        void syncActualSendFps();
+        sendFpsInterval = setInterval(() => {
+            void syncActualSendFps();
+        }, 1000);
+    };
+
     onCleanup(async () => {
+        stopActualSendFps();
         if (stop) {
             await stop();
             stop = undefined;
@@ -248,6 +301,7 @@ export default function Publisher() {
 
     const start = async () => {
         setDisabled(true);
+        stopActualSendFps();
         clear();
         const streamId = ((searchParams.id as string) || "").trim();
         if (!streamId) {
@@ -304,6 +358,15 @@ export default function Publisher() {
             onChannel: (channel: RTCDataChannel): void => {
                 setDatachannel(channel);
             },
+            onPeerConnection: (
+                peerConnection: RTCPeerConnection | null,
+            ): void => {
+                if (peerConnection) {
+                    startActualSendFps(peerConnection);
+                } else {
+                    stopActualSendFps();
+                }
+            },
             log: setLogs,
         });
         if (isQrMode) {
@@ -344,6 +407,7 @@ export default function Publisher() {
 
     const updateQrFrameRate = (frameRate: QRCodeFrameRate) => {
         setSelectQrFrameRate(frameRate);
+        setSearchParams({ qrfps: frameRate.toString() });
         if (sourceMode() !== "qrtime" || qrState() !== "previewing") {
             return;
         }
@@ -359,6 +423,16 @@ export default function Publisher() {
         setQrState("previewing");
         setLogs(`QR source updated to ${frameRate} fps.`);
     };
+
+    createEffect(() => {
+        const frameRate = parseQRCodeFrameRate(searchParams.qrfps);
+        if (sourceMode() === "qrtime" && qrState() === "publishing") {
+            return;
+        }
+        if (frameRate !== selectQrFrameRate()) {
+            updateQrFrameRate(frameRate);
+        }
+    });
 
     return (
         <>
@@ -534,10 +608,9 @@ export default function Publisher() {
                                 value={selectQrFrameRate()}
                                 onChange={(e) => {
                                     updateQrFrameRate(
-                                        Number.parseInt(
+                                        parseQRCodeFrameRate(
                                             e.currentTarget.value,
-                                            10,
-                                        ) as QRCodeFrameRate,
+                                        ),
                                     );
                                 }}
                             >
@@ -567,6 +640,9 @@ export default function Publisher() {
                     <h5>
                         Audio Track Count: {audioTrackCount()}, Video Track
                         Count: {videoTrackCount()}
+                        <Show when={sourceMode() === "qrtime"}>
+                            {` | Target FPS: ${selectQrFrameRate()} | Actual Send FPS: ${formatFps(actualSendFps())}`}
+                        </Show>
                     </h5>
                     <Show when={stream()}>
                         {(ms) => <Player stream={ms()} />}

--- a/web/debugger/components/publisher.tsx
+++ b/web/debugger/components/publisher.tsx
@@ -1,10 +1,6 @@
 import { useSearchParams } from "@solidjs/router";
 import { createEffect, createSignal, onCleanup, Show } from "solid-js";
 import {
-    collectVideoRtpFps,
-    type VideoFpsSamples,
-} from "../../player-core/webrtc-stats";
-import {
     parseQRCodeFrameRate,
     type QRCodeFrameRate,
     QRCodeFrameRates,
@@ -74,10 +70,6 @@ type QrState = "idle" | "previewing" | "publishing";
 const QrCanvasWidth = 480;
 const QrCanvasHeight = 320;
 
-function formatFps(fps: number | null) {
-    return fps === null ? "--" : fps.toFixed(1);
-}
-
 export default function Publisher() {
     const [searchParams, setSearchParams] = useSearchParams();
 
@@ -99,7 +91,6 @@ export default function Publisher() {
     const [selectVideoLayer, setSelectVideoLayer] = createSignal("f");
     const [selectQrFrameRate, setSelectQrFrameRate] =
         createSignal<QRCodeFrameRate>(parseQRCodeFrameRate(searchParams.qrfps));
-    const [actualSendFps, setActualSendFps] = createSignal<number | null>(null);
 
     const [audioTrackCount, setAudioTrackCount] = createSignal(0);
     const [videoTrackCount, setVideoTrackCount] = createSignal(0);
@@ -110,10 +101,6 @@ export default function Publisher() {
     let qrCanvasRef: HTMLCanvasElement | undefined;
     let qrStream: QRCodeStream | null = null;
     let desktopStreamCleanupInProgress = false;
-    let publisherPeerConnection: RTCPeerConnection | null = null;
-    let sendFpsSamples: VideoFpsSamples = {};
-    let sendFpsInterval: ReturnType<typeof setInterval> | null = null;
-    let sendFpsToken = 0;
 
     const selectedVideoCodec = () => (searchParams.vcodec as string) || "";
 
@@ -170,47 +157,7 @@ export default function Publisher() {
         }
     };
 
-    const stopActualSendFps = () => {
-        sendFpsToken += 1;
-        if (sendFpsInterval) {
-            clearInterval(sendFpsInterval);
-            sendFpsInterval = null;
-        }
-        publisherPeerConnection = null;
-        sendFpsSamples = {};
-        setActualSendFps(null);
-    };
-
-    const startActualSendFps = (peerConnection: RTCPeerConnection) => {
-        stopActualSendFps();
-        publisherPeerConnection = peerConnection;
-        const token = sendFpsToken;
-
-        const syncActualSendFps = async () => {
-            const currentPeerConnection = publisherPeerConnection;
-            if (!currentPeerConnection) {
-                return;
-            }
-            const stats = await collectVideoRtpFps(
-                currentPeerConnection,
-                "outbound",
-                sendFpsSamples,
-            );
-            if (token !== sendFpsToken) {
-                return;
-            }
-            sendFpsSamples = stats.samples;
-            setActualSendFps(stats.fps);
-        };
-
-        void syncActualSendFps();
-        sendFpsInterval = setInterval(() => {
-            void syncActualSendFps();
-        }, 1000);
-    };
-
     onCleanup(async () => {
-        stopActualSendFps();
         if (stop) {
             await stop();
             stop = undefined;
@@ -301,7 +248,6 @@ export default function Publisher() {
 
     const start = async () => {
         setDisabled(true);
-        stopActualSendFps();
         clear();
         const streamId = ((searchParams.id as string) || "").trim();
         if (!streamId) {
@@ -357,15 +303,6 @@ export default function Publisher() {
             },
             onChannel: (channel: RTCDataChannel): void => {
                 setDatachannel(channel);
-            },
-            onPeerConnection: (
-                peerConnection: RTCPeerConnection | null,
-            ): void => {
-                if (peerConnection) {
-                    startActualSendFps(peerConnection);
-                } else {
-                    stopActualSendFps();
-                }
             },
             log: setLogs,
         });
@@ -641,11 +578,16 @@ export default function Publisher() {
                         Audio Track Count: {audioTrackCount()}, Video Track
                         Count: {videoTrackCount()}
                         <Show when={sourceMode() === "qrtime"}>
-                            {` | Target FPS: ${selectQrFrameRate()} | Actual Send FPS: ${formatFps(actualSendFps())}`}
+                            {` | QR Target FPS: ${selectQrFrameRate()}`}
                         </Show>
                     </h5>
                     <Show when={stream()}>
-                        {(ms) => <Player stream={ms()} />}
+                        {(ms) => (
+                            <Player
+                                stream={ms()}
+                                showRenderFps={sourceMode() === "qrtime"}
+                            />
+                        )}
                     </Show>
                 </section>
                 <section>

--- a/web/debugger/components/subscriber.tsx
+++ b/web/debugger/components/subscriber.tsx
@@ -2,10 +2,6 @@ import { useSearchParams } from "@solidjs/router";
 import { createWhepPlayback } from "player-core";
 import { createEffect, createSignal, onCleanup, Show } from "solid-js";
 import {
-    collectVideoRtpFps,
-    type VideoFpsSamples,
-} from "../../player-core/webrtc-stats";
-import {
     DefaultQRCodeFrameRate,
     parseQRCodeFrameRate,
     type QRCodeFrameRate,
@@ -22,10 +18,6 @@ const WhepLayerOptions = [
     { value: "f", text: "HIGH" },
 ];
 
-function formatFps(fps: number | null) {
-    return fps === null ? "--" : fps.toFixed(1);
-}
-
 export default function Subscriber() {
     const [searchParams] = useSearchParams();
 
@@ -40,15 +32,9 @@ export default function Subscriber() {
         createSignal<QRCodeFrameRate>(
             parseQRCodeFrameRate(searchParams.qrfps ?? DefaultQRCodeFrameRate),
         );
-    const [actualReceiveFps, setActualReceiveFps] = createSignal<number | null>(
-        null,
-    );
 
     let videoRef: HTMLVideoElement | undefined;
     let decoder: QRCodeStreamDecoder | null = null;
-    let receiveFpsSamples: VideoFpsSamples = {};
-    let receiveFpsInterval: ReturnType<typeof setInterval> | null = null;
-    let receiveFpsToken = 0;
 
     const playback = createWhepPlayback({
         url: () => {
@@ -61,7 +47,6 @@ export default function Subscriber() {
     });
 
     onCleanup(() => {
-        stopActualReceiveFps();
         stopQrLatencyMeasure();
         void playback.stop({ reconnect: false });
     });
@@ -71,48 +56,6 @@ export default function Subscriber() {
             stopQrLatencyMeasure();
         }
     });
-
-    createEffect(() => {
-        const peerConnection = playback.peerConnection();
-        if (peerConnection) {
-            startActualReceiveFps(peerConnection);
-        } else {
-            stopActualReceiveFps();
-        }
-    });
-
-    function stopActualReceiveFps() {
-        receiveFpsToken += 1;
-        if (receiveFpsInterval) {
-            clearInterval(receiveFpsInterval);
-            receiveFpsInterval = null;
-        }
-        receiveFpsSamples = {};
-        setActualReceiveFps(null);
-    }
-
-    function startActualReceiveFps(peerConnection: RTCPeerConnection) {
-        stopActualReceiveFps();
-        const token = receiveFpsToken;
-
-        const syncActualReceiveFps = async () => {
-            const stats = await collectVideoRtpFps(
-                peerConnection,
-                "inbound",
-                receiveFpsSamples,
-            );
-            if (token !== receiveFpsToken) {
-                return;
-            }
-            receiveFpsSamples = stats.samples;
-            setActualReceiveFps(stats.fps);
-        };
-
-        void syncActualReceiveFps();
-        receiveFpsInterval = setInterval(() => {
-            void syncActualReceiveFps();
-        }, 1000);
-    }
 
     createEffect(() => {
         const frameRate = parseQRCodeFrameRate(
@@ -224,8 +167,6 @@ export default function Subscriber() {
                     </button>
                 </section>
 
-                <section>Expected QR FPS: {expectedQrFrameRate()} fps</section>
-
                 <section>
                     <button
                         type="button"
@@ -252,7 +193,7 @@ export default function Subscriber() {
                     <h5>
                         Audio Track Count: {playback.audioTrackCount()}, Video
                         Track Count: {playback.videoTrackCount()}
-                        {` | Expected FPS: ${expectedQrFrameRate()} | Actual Receive FPS: ${formatFps(actualReceiveFps())}`}
+                        {` | QR Target FPS: ${expectedQrFrameRate()}`}
                         {latency() && ` | Latency: ${latency()}`}
                     </h5>
                     <Show when={playback.stream()}>
@@ -261,6 +202,7 @@ export default function Subscriber() {
                             return (
                                 <Player
                                     stream={stream}
+                                    showRenderFps
                                     onVideoElement={(video) => {
                                         videoRef = video;
                                     }}

--- a/web/debugger/components/subscriber.tsx
+++ b/web/debugger/components/subscriber.tsx
@@ -1,7 +1,16 @@
 import { useSearchParams } from "@solidjs/router";
 import { createWhepPlayback } from "player-core";
 import { createEffect, createSignal, onCleanup, Show } from "solid-js";
-import { QRCodeStreamDecoder } from "../../shared/qrcode-stream";
+import {
+    collectVideoRtpFps,
+    type VideoFpsSamples,
+} from "../../player-core/webrtc-stats";
+import {
+    DefaultQRCodeFrameRate,
+    parseQRCodeFrameRate,
+    type QRCodeFrameRate,
+    QRCodeStreamDecoder,
+} from "../../shared/qrcode-stream";
 import { createLogger } from "../primitive/logger";
 import Datachannel from "./datachannel";
 import Player from "./player";
@@ -13,7 +22,13 @@ const WhepLayerOptions = [
     { value: "f", text: "HIGH" },
 ];
 
+function formatFps(fps: number | null) {
+    return fps === null ? "--" : fps.toFixed(1);
+}
+
 export default function Subscriber() {
+    const [searchParams] = useSearchParams();
+
     const [disabled, setDisabled] = createSignal(true);
     const [disabledAudio, setDisabledAudio] = createSignal(false);
     const [disabledVideo, setDisabledVideo] = createSignal(false);
@@ -21,10 +36,19 @@ export default function Subscriber() {
 
     const [latency, setLatency] = createSignal("");
     const [isMeasuringQrLatency, setIsMeasuringQrLatency] = createSignal(false);
+    const [expectedQrFrameRate, setExpectedQrFrameRate] =
+        createSignal<QRCodeFrameRate>(
+            parseQRCodeFrameRate(searchParams.qrfps ?? DefaultQRCodeFrameRate),
+        );
+    const [actualReceiveFps, setActualReceiveFps] = createSignal<number | null>(
+        null,
+    );
 
-    const [searchParams] = useSearchParams();
     let videoRef: HTMLVideoElement | undefined;
     let decoder: QRCodeStreamDecoder | null = null;
+    let receiveFpsSamples: VideoFpsSamples = {};
+    let receiveFpsInterval: ReturnType<typeof setInterval> | null = null;
+    let receiveFpsToken = 0;
 
     const playback = createWhepPlayback({
         url: () => {
@@ -37,6 +61,7 @@ export default function Subscriber() {
     });
 
     onCleanup(() => {
+        stopActualReceiveFps();
         stopQrLatencyMeasure();
         void playback.stop({ reconnect: false });
     });
@@ -47,16 +72,67 @@ export default function Subscriber() {
         }
     });
 
-    const stopQrLatencyMeasure = () => {
+    createEffect(() => {
+        const peerConnection = playback.peerConnection();
+        if (peerConnection) {
+            startActualReceiveFps(peerConnection);
+        } else {
+            stopActualReceiveFps();
+        }
+    });
+
+    function stopActualReceiveFps() {
+        receiveFpsToken += 1;
+        if (receiveFpsInterval) {
+            clearInterval(receiveFpsInterval);
+            receiveFpsInterval = null;
+        }
+        receiveFpsSamples = {};
+        setActualReceiveFps(null);
+    }
+
+    function startActualReceiveFps(peerConnection: RTCPeerConnection) {
+        stopActualReceiveFps();
+        const token = receiveFpsToken;
+
+        const syncActualReceiveFps = async () => {
+            const stats = await collectVideoRtpFps(
+                peerConnection,
+                "inbound",
+                receiveFpsSamples,
+            );
+            if (token !== receiveFpsToken) {
+                return;
+            }
+            receiveFpsSamples = stats.samples;
+            setActualReceiveFps(stats.fps);
+        };
+
+        void syncActualReceiveFps();
+        receiveFpsInterval = setInterval(() => {
+            void syncActualReceiveFps();
+        }, 1000);
+    }
+
+    createEffect(() => {
+        const frameRate = parseQRCodeFrameRate(
+            searchParams.qrfps ?? DefaultQRCodeFrameRate,
+        );
+        if (frameRate !== expectedQrFrameRate()) {
+            setExpectedQrFrameRate(frameRate);
+        }
+    });
+
+    function stopQrLatencyMeasure() {
         if (decoder) {
             decoder.stop();
             decoder = null;
         }
         setIsMeasuringQrLatency(false);
         setLatency("");
-    };
+    }
 
-    const startQrLatencyMeasure = () => {
+    function startQrLatencyMeasure() {
         if (!videoRef || !playback.stream()) {
             return;
         }
@@ -68,7 +144,7 @@ export default function Subscriber() {
             setLatency(`${e.detail} ms`);
         });
         decoder.start();
-    };
+    }
 
     const start = async () => {
         clear();
@@ -148,6 +224,8 @@ export default function Subscriber() {
                     </button>
                 </section>
 
+                <section>Expected QR FPS: {expectedQrFrameRate()} fps</section>
+
                 <section>
                     <button
                         type="button"
@@ -174,6 +252,7 @@ export default function Subscriber() {
                     <h5>
                         Audio Track Count: {playback.audioTrackCount()}, Video
                         Track Count: {playback.videoTrackCount()}
+                        {` | Expected FPS: ${expectedQrFrameRate()} | Actual Receive FPS: ${formatFps(actualReceiveFps())}`}
                         {latency() && ` | Latency: ${latency()}`}
                     </h5>
                     <Show when={playback.stream()}>

--- a/web/player-core/index.ts
+++ b/web/player-core/index.ts
@@ -1,7 +1,11 @@
 export { default as PlayerSurface } from "./player-surface";
 export { default as StatsForNerds } from "./stats";
 export type { StatsNerds } from "./types";
-export { collectWebRtcStats } from "./webrtc-stats";
+export {
+    collectVideoRtpFps,
+    collectWebRtcStats,
+    type VideoFpsSamples,
+} from "./webrtc-stats";
 export {
     createWhepPlayback,
     type WhepMute,

--- a/web/player-core/webrtc-stats.ts
+++ b/web/player-core/webrtc-stats.ts
@@ -1,5 +1,94 @@
 import type { StatsNerds } from "./types";
 
+export type VideoRtpDirection = "inbound" | "outbound";
+
+export type VideoFpsSample = {
+    frames: number;
+    timestamp: number;
+};
+
+export type VideoFpsSamples = Record<string, VideoFpsSample>;
+
+export type VideoFpsStats = {
+    fps: number | null;
+    samples: VideoFpsSamples;
+};
+
+function getFrameCount(
+    report: RTCInboundRtpStreamStats | RTCOutboundRtpStreamStats,
+    direction: VideoRtpDirection,
+): number | undefined {
+    if (direction === "inbound") {
+        const inboundReport = report as RTCInboundRtpStreamStats;
+        return inboundReport.framesDecoded ?? inboundReport.framesReceived;
+    }
+    const outboundReport = report as RTCOutboundRtpStreamStats;
+    return outboundReport.framesEncoded ?? outboundReport.framesSent;
+}
+
+function calculateFps(
+    report: RTCInboundRtpStreamStats | RTCOutboundRtpStreamStats,
+    direction: VideoRtpDirection,
+    previousSample: VideoFpsSample | null,
+): { fps: number | null; sample: VideoFpsSample | null } {
+    const framesPerSecond = report.framesPerSecond;
+    const frames = getFrameCount(report, direction);
+    const sample =
+        typeof frames === "number"
+            ? { frames, timestamp: report.timestamp }
+            : null;
+
+    if (typeof framesPerSecond === "number") {
+        return { fps: framesPerSecond, sample };
+    }
+    if (
+        !sample ||
+        !previousSample ||
+        sample.timestamp <= previousSample.timestamp
+    ) {
+        return { fps: null, sample };
+    }
+
+    const frameDelta = sample.frames - previousSample.frames;
+    const timeDeltaSeconds =
+        (sample.timestamp - previousSample.timestamp) / 1000;
+    if (frameDelta < 0 || timeDeltaSeconds <= 0) {
+        return { fps: null, sample };
+    }
+    return { fps: frameDelta / timeDeltaSeconds, sample };
+}
+
+export async function collectVideoRtpFps(
+    peerConnection: RTCPeerConnection,
+    direction: VideoRtpDirection,
+    previousSamples: VideoFpsSamples,
+): Promise<VideoFpsStats> {
+    const stats = await peerConnection.getStats();
+    const reportType = `${direction}-rtp`;
+    const samples: VideoFpsSamples = {};
+    let fps: number | null = null;
+
+    stats.forEach((report) => {
+        if (report.type !== reportType || report.kind !== "video") {
+            return;
+        }
+
+        const nextResult = calculateFps(
+            report as RTCInboundRtpStreamStats | RTCOutboundRtpStreamStats,
+            direction,
+            previousSamples[report.id] ?? null,
+        );
+        if (nextResult.sample) {
+            samples[report.id] = nextResult.sample;
+        }
+        if (nextResult.fps !== null && (fps === null || nextResult.fps > fps)) {
+            fps = nextResult.fps;
+        }
+    });
+
+    return { fps, samples };
+}
+
 export async function collectWebRtcStats(
     peerConnection: RTCPeerConnection,
 ): Promise<StatsNerds> {

--- a/web/shared/components/dialog-web-stream.tsx
+++ b/web/shared/components/dialog-web-stream.tsx
@@ -1,4 +1,4 @@
-import { useRef, useImperativeHandle, useState, useContext } from 'preact/hooks';
+import { useRef, useImperativeHandle, useState, useContext, useEffect } from 'preact/hooks';
 import { TargetedEvent, forwardRef } from 'preact/compat';
 import { Button, Collapse, Modal } from 'react-daisyui';
 import { WHIPClient } from '@binbat/whip-whep/whip';
@@ -6,7 +6,12 @@ import { WHIPClient } from '@binbat/whip-whep/whip';
 import { TokenContext } from '../context';
 import { formatVideoTrackResolution } from '../utils';
 import { useLogger } from '../hooks/use-logger';
-import { QRCodeStream } from '../qrcode-stream';
+import {
+    DefaultQRCodeFrameRate,
+    type QRCodeFrameRate,
+    QRCodeFrameRates,
+    QRCodeStream
+} from '../qrcode-stream';
 import convertSessionDescription from '../sdp-codec';
 
 interface Props {
@@ -31,6 +36,11 @@ export const WebStreamDialog = forwardRef<IWebStreamDialog, Props>((props, ref) 
     const refCanvas = useRef<HTMLCanvasElement>(null);
     const refQrCodeStream = useRef<QRCodeStream>(null);
     const [qrPreviewing, setQrPreviewing] = useState(false);
+    const [qrSourceHidden, setQrSourceHidden] = useState(false);
+    const refQrSourceHiddenLogged = useRef(false);
+    const [qrFrameRate, setQrFrameRate] = useState<QRCodeFrameRate>(
+        DefaultQRCodeFrameRate
+    );
 
     useImperativeHandle(ref, () => {
         return {
@@ -49,6 +59,27 @@ export const WebStreamDialog = forwardRef<IWebStreamDialog, Props>((props, ref) 
         setConnState(state);
         logger.log(state);
     };
+
+    useEffect(() => {
+        const handleVisibilityChange = () => {
+            if (
+                document.visibilityState !== 'hidden' ||
+                !refQrCodeStream.current ||
+                !refWhipClient.current
+            ) {
+                return;
+            }
+            setQrSourceHidden(true);
+            if (!refQrSourceHiddenLogged.current) {
+                logger.log('QR source page is hidden; browser timer throttling may reduce QR fps.');
+                refQrSourceHiddenLogged.current = true;
+            }
+        };
+        document.addEventListener('visibilitychange', handleVisibilityChange);
+        return () => {
+            document.removeEventListener('visibilitychange', handleVisibilityChange);
+        };
+    }, []);
 
     const handleStreamStart = async (stream: MediaStream) => {
         logger.clear();
@@ -109,8 +140,13 @@ export const WebStreamDialog = forwardRef<IWebStreamDialog, Props>((props, ref) 
     };
 
     const handleEncodeLatencyPreview = () => {
+        setQrSourceHidden(false);
+        refQrSourceHiddenLogged.current = false;
         if (!refQrCodeStream.current) {
-            refQrCodeStream.current = new QRCodeStream(refCanvas.current!);
+            refQrCodeStream.current = new QRCodeStream(
+                refCanvas.current!,
+                qrFrameRate
+            );
         }
         const stream = refQrCodeStream.current.capture();
         refMediaStream.current = stream;
@@ -120,15 +156,40 @@ export const WebStreamDialog = forwardRef<IWebStreamDialog, Props>((props, ref) 
         setQrPreviewing(true);
     };
 
+    const updateQrFrameRate = (frameRate: QRCodeFrameRate) => {
+        setQrFrameRate(frameRate);
+        if (!qrPreviewing || refWhipClient.current) {
+            return;
+        }
+
+        if (refQrCodeStream.current) {
+            refQrCodeStream.current.stop();
+            refQrCodeStream.current = null;
+        }
+        refQrCodeStream.current = new QRCodeStream(
+            refCanvas.current!,
+            frameRate
+        );
+        const stream = refQrCodeStream.current.capture();
+        refMediaStream.current = stream;
+        if (refVideo.current) {
+            refVideo.current.srcObject = stream;
+        }
+        logger.log(`QR source updated to ${frameRate} fps.`);
+    };
+
     const handleEncodeLatencyPublish = () => {
         if (refMediaStream.current) {
             handleStreamStart(refMediaStream.current);
+            logger.log('For QR latency testing, keep this source page visible and use Preview -> Decode Latency on this page.');
             setQrPreviewing(false);
         }
     };
 
     const handleStreamStop = async () => {
         setQrPreviewing(false);
+        setQrSourceHidden(false);
+        refQrSourceHiddenLogged.current = false;
         if (refQrCodeStream.current) {
             refQrCodeStream.current.stop();
             refQrCodeStream.current = null;
@@ -163,7 +224,7 @@ export const WebStreamDialog = forwardRef<IWebStreamDialog, Props>((props, ref) 
             <Modal.Body>
                 <video
                     ref={refVideo}
-                    className="mx-[-1.5rem] min-w-[28rem] max-w-[90vw] max-h-[70vh]"
+                    className="block mx-auto min-w-[28rem] max-w-[90vw] max-h-[70vh]"
                     onResize={handleVideoResize}
                     controls autoplay
                 />
@@ -176,8 +237,32 @@ export const WebStreamDialog = forwardRef<IWebStreamDialog, Props>((props, ref) 
                         <pre class="overflow-auto max-h-[10lh]">{logger.logs.join('\n')}</pre>
                     </Collapse.Content>
                 </Collapse.Details>
+                {qrSourceHidden ? (
+                    <div className="alert alert-warning mt-2">
+                        <span>QR source page was hidden; browser timer throttling may reduce QR fps.</span>
+                    </div>
+                ) : null}
             </Modal.Body>
             <Modal.Actions className="mt-0">
+                <label className="mr-auto">
+                    QR Frame Rate:
+                    <select
+                        disabled={!!refWhipClient.current}
+                        value={qrFrameRate}
+                        onChange={(e) => {
+                            updateQrFrameRate(
+                                Number.parseInt(
+                                    e.currentTarget.value,
+                                    10
+                                ) as QRCodeFrameRate
+                            );
+                        }}
+                    >
+                        {QRCodeFrameRates.map(frameRate => (
+                            <option value={frameRate}>{frameRate} fps</option>
+                        ))}
+                    </select>
+                </label>
                 {refWhipClient.current ? (
                     <Button color="error" onClick={handleStreamStop}>Stop</Button>
                 ) : qrPreviewing ? (

--- a/web/shared/qrcode-stream.ts
+++ b/web/shared/qrcode-stream.ts
@@ -13,6 +13,12 @@ function timestamp(value: number) {
     return `${s}.${ms}`;
 }
 
+export type QRCodeFrameRate = 30 | 60 | 120 | 144 | 200;
+
+export const QRCodeFrameRates: QRCodeFrameRate[] = [30, 60, 120, 144, 200];
+
+export const DefaultQRCodeFrameRate: QRCodeFrameRate = 30;
+
 export class QRCodeStream {
 
     static White = '#fff';
@@ -30,12 +36,17 @@ export class QRCodeStream {
     private textOriginY: number;
 
     private scheduled = false;
-    private frameRequestCallback: FrameRequestCallback;
+    private timer: number | null = null;
+    private nextFrameAt = 0;
+    private captureTrack: CanvasCaptureMediaStreamTrack | null = null;
 
     private capturing: MediaStream | null = null;
     public canvas: HTMLCanvasElement;
 
-    constructor(canvas: HTMLCanvasElement) {
+    constructor(
+        canvas: HTMLCanvasElement,
+        private frameRate: QRCodeFrameRate = DefaultQRCodeFrameRate
+    ) {
         this.canvas = canvas;
         this.encoder = new Encoder({ level: 'L' });
         const { width, height } = canvas;
@@ -45,7 +56,6 @@ export class QRCodeStream {
         this.qrSize = Math.min(width, height);
         this.qrMarginX = (width - this.qrSize) / 2;
         this.qrMarginY = (height - this.qrSize) / 2;
-        this.frameRequestCallback = this.frameRequestCallback_unbound.bind(this);
         const textMarginX = Math.max(4, width * 0.01);
         const textMarginY = Math.max(4, height * 0.01);
         let fontSize = 1000;
@@ -93,13 +103,32 @@ export class QRCodeStream {
             }
         }
         this.ctx.fillText(timestamp(now), this.textOriginX, this.textOriginY);
+        this.captureTrack?.requestFrame();
     }
 
-    private frameRequestCallback_unbound(_time: DOMHighResTimeStamp) {
-        const now = Date.now();
-        this.doFrame(now);
+    private scheduleFrame() {
+        const frameInterval = 1000 / this.frameRate;
+        const now = performance.now();
+        if (this.nextFrameAt <= now) {
+            this.nextFrameAt = now + frameInterval;
+        }
+        this.timer = window.setTimeout(
+            () => this.frameRequestCallback_unbound(),
+            Math.max(0, this.nextFrameAt - now)
+        );
+    }
+
+    private frameRequestCallback_unbound() {
+        const frameInterval = 1000 / this.frameRate;
+        const now = performance.now();
+        this.nextFrameAt += frameInterval;
+        if (this.nextFrameAt <= now) {
+            const skippedFrames = Math.floor((now - this.nextFrameAt) / frameInterval) + 1;
+            this.nextFrameAt += skippedFrames * frameInterval;
+        }
+        this.doFrame(Date.now());
         if (this.scheduled) {
-            window.requestAnimationFrame(this.frameRequestCallback);
+            this.scheduleFrame();
         }
     }
 
@@ -107,12 +136,21 @@ export class QRCodeStream {
         if (this.capturing) {
             return this.capturing;
         }
+        let ms = this.canvas.captureStream(0);
+        const [track] = ms.getVideoTracks();
+        if (track && 'requestFrame' in track) {
+            this.captureTrack = track as CanvasCaptureMediaStreamTrack;
+        } else {
+            ms.getTracks().forEach(t => t.stop());
+            ms = this.canvas.captureStream(this.frameRate);
+        }
+        this.capturing = ms;
         if (!this.scheduled) {
             this.scheduled = true;
-            window.requestAnimationFrame(this.frameRequestCallback);
+            this.nextFrameAt = performance.now();
+            this.doFrame(Date.now());
+            this.scheduleFrame();
         }
-        const ms = this.canvas.captureStream();
-        this.capturing = ms;
         return ms;
     }
 
@@ -120,10 +158,15 @@ export class QRCodeStream {
         if (this.scheduled) {
             this.scheduled = false;
         }
+        if (this.timer !== null) {
+            window.clearTimeout(this.timer);
+            this.timer = null;
+        }
         if (this.capturing) {
             this.capturing.getTracks().forEach(t => t.stop());
             this.capturing = null;
         }
+        this.captureTrack = null;
     }
 
 }

--- a/web/shared/qrcode-stream.ts
+++ b/web/shared/qrcode-stream.ts
@@ -19,6 +19,13 @@ export const QRCodeFrameRates: QRCodeFrameRate[] = [30, 60, 120, 144, 200];
 
 export const DefaultQRCodeFrameRate: QRCodeFrameRate = 30;
 
+export function parseQRCodeFrameRate(value: unknown): QRCodeFrameRate {
+    const frameRate = typeof value === 'number' ? value : Number.parseInt(String(value), 10);
+    return QRCodeFrameRates.includes(frameRate as QRCodeFrameRate)
+        ? frameRate as QRCodeFrameRate
+        : DefaultQRCodeFrameRate;
+}
+
 export class QRCodeStream {
 
     static White = '#fff';

--- a/web/shared/qrcode-stream.ts
+++ b/web/shared/qrcode-stream.ts
@@ -13,9 +13,9 @@ function timestamp(value: number) {
     return `${s}.${ms}`;
 }
 
-export type QRCodeFrameRate = 30 | 60 | 120 | 144 | 200;
+export type QRCodeFrameRate = 30 | 60 | 120 | 144 | 200 | 500;
 
-export const QRCodeFrameRates: QRCodeFrameRate[] = [30, 60, 120, 144, 200];
+export const QRCodeFrameRates: QRCodeFrameRate[] = [30, 60, 120, 144, 200, 500];
 
 export const DefaultQRCodeFrameRate: QRCodeFrameRate = 30;
 
@@ -46,15 +46,17 @@ export class QRCodeStream {
     private timer: number | null = null;
     private nextFrameAt = 0;
     private captureTrack: CanvasCaptureMediaStreamTrack | null = null;
+    private frameRate: QRCodeFrameRate;
 
     private capturing: MediaStream | null = null;
     public canvas: HTMLCanvasElement;
 
     constructor(
         canvas: HTMLCanvasElement,
-        private frameRate: QRCodeFrameRate = DefaultQRCodeFrameRate
+        frameRate: QRCodeFrameRate = DefaultQRCodeFrameRate
     ) {
         this.canvas = canvas;
+        this.frameRate = frameRate;
         this.encoder = new Encoder({ level: 'L' });
         const { width, height } = canvas;
         this.width = width;


### PR DESCRIPTION
## Summary
- add selectable QR latency frame rates for the debugger publisher
- thread the selected frame rate through web stream dialog setup
- pace QR canvas capture frames according to the selected rate

## Checks
- pnpm exec biome ci .
- pnpm -r build
- cargo fmt --all -- --check
- cargo clippy --all-targets --no-default-features --workspace -- -D warnings
- cargo clippy --all-targets --workspace -- -D warnings
- cargo clippy --all-targets --features=net4mqtt,recorder,source-all --workspace -- -D warnings
- cargo clippy --all-targets --all-features --workspace -- -D warnings
- cargo build --all-targets --all-features --release --verbose

Note: pnpm build emitted existing Vite/Tailwind/CSS minify warnings; cargo build emitted a readonly global cache last-use warning. All checks exited 0.