### PR TITLE
Feat/av1 whipinto support pkt_size greater than 1200

### DIFF
--- a/docs/guide/ffmpeg.md
+++ b/docs/guide/ffmpeg.md
@@ -101,7 +101,6 @@ whipinto -i input.sdp -w http://localhost:7777/whip/777
 
 ::: warning
 - Please set `-strict experimental`
-- For whipinto AV1 need `pkt_size<=1200`, `-f rtp "rtp://127.0.0.1:5002?pkt_size=1200"`
 :::
 
 ```bash
@@ -109,7 +108,7 @@ ffmpeg -re -f lavfi -i testsrc=size=640x360:rate=30 -pix_fmt yuv420p \
 -c:v libaom-av1 -cpu-used 8 -tile-columns 0 -tile-rows 0 -row-mt 1 \
 -lag-in-frames 0 -g 30 -keyint_min 30 -b:v 0 -crf 30 -threads 4 \
 -strict experimental \
--f rtp "rtp://127.0.0.1:5002?pkt_size=1200" -sdp_file input.sdp
+-f rtp "rtp://127.0.0.1:5002" -sdp_file input.sdp
 ```
 
 ## VP8

--- a/docs/guide/whipinto.md
+++ b/docs/guide/whipinto.md
@@ -127,11 +127,11 @@ WebRTC must need `pkt_size<=1200`
 If `pkt_size > 1200` (most tool default `> 1200`, for example: `ffmpeg` default `1472`), we need to de-payload after re-payload
 :::
 
-But now, We support re-size `pkt_size` in `VP8` and `VP9`, You can use any `pkt_size` value in `VP8` and `VP9`
+But now, We support re-size `pkt_size` in `AV1`, `VP8` and `VP9`, You can use any `pkt_size` value in `AV1`, `VP8` and `VP9`
 
 Codec             | `AV1`  | `VP9`  | `VP8`  | `H264` | `H265` | `OPUS` | `G722` |
 ----------------- | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-`pkt_size > 1200` | :shit: | :star: | :star: | :star: | :star: | :star: | :shit: |
+`pkt_size > 1200` | :star: | :star: | :star: | :star: | :star: | :star: | :shit: |
 
 - :star: It's working
 - :shit: Don't support

--- a/docs/zh/guide/ffmpeg.md
+++ b/docs/zh/guide/ffmpeg.md
@@ -101,7 +101,6 @@ whipinto -i input.sdp -w http://localhost:7777/whip/777
 
 ::: warning
 - 需要设置 `-strict experimental`
-- 对于 `whipinto` AV1 需要设置 `pkt_size<=1200`，`-f rtp "rtp://127.0.0.1:5002?pkt_size=1200"`
 :::
 
 ```bash
@@ -109,7 +108,7 @@ ffmpeg -re -f lavfi -i testsrc=size=640x360:rate=30 -pix_fmt yuv420p \
 -c:v libaom-av1 -cpu-used 8 -tile-columns 0 -tile-rows 0 -row-mt 1 \
 -lag-in-frames 0 -g 30 -keyint_min 30 -b:v 0 -crf 30 -threads 4 \
 -strict experimental \
--f rtp "rtp://127.0.0.1:5002?pkt_size=1200" -sdp_file input.sdp
+-f rtp "rtp://127.0.0.1:5002" -sdp_file input.sdp
 ```
 
 ## VP8

--- a/docs/zh/guide/whipinto.md
+++ b/docs/zh/guide/whipinto.md
@@ -127,11 +127,11 @@ WebRTC必须满足 `pkt_size<=1200`
 当 `pkt_size > 1200` 时（多数工具默认值 `> 1200`，例如： `ffmpeg` 默认 `1472`)，需要进行解封装后重新封装处理
 :::
 
-不过现在，我们已经在 `VP8` 和 `VP9` 编解码器中支持重新调整 `pkt_size` ，您可以在 `VP8` 和 `VP9` 中使用任意大小的 `pkt_size`值
+不过现在，我们已经在 `AV1`、`VP8` 和 `VP9` 编解码器中支持重新调整 `pkt_size`，您可以在 `AV1`、`VP8` 和 `VP9` 中使用任意大小的 `pkt_size` 值
 
 Codec             | `AV1`  | `VP9`  | `VP8`  | `H264` | `H265` | `OPUS` | `G722` |
 ----------------- | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-`pkt_size > 1200` | :shit: | :star: | :star: | :star: | :star: | :star: | :shit: |
+`pkt_size > 1200` | :star: | :star: | :star: | :star: | :star: | :star: | :shit: |
 
 - :star: 正常运行
 - :shit: 不支持

--- a/justfile
+++ b/justfile
@@ -18,6 +18,7 @@ h264 := "libx264 -pix_fmt yuv420p -g 60 -keyint_min 60 -crf 23 -preset ultrafast
 h265 := "libx265 -pix_fmt yuv420p -g 60 -keyint_min 60 -crf 25 -preset ultrafast -tune zerolatency -profile:v main -level 4.1"
 vp8  := "libvpx -pix_fmt yuv420p -g 60 -keyint_min 60 -deadline realtime -speed 4 -b:v 2000k -maxrate 2500k -bufsize 5000k"
 vp9  := "libvpx-vp9 -pix_fmt yuv420p -g 60 -keyint_min 60 -deadline realtime -speed 5 -row-mt 1 -tile-columns 2 -frame-parallel 1 -b:v 1800k -maxrate 2200k -bufsize 4400k"
+av1  := "libaom-av1 -cpu-used 8 -tile-columns 0 -tile-rows 0 -row-mt 1 -lag-in-frames 0 -g 30 -keyint_min 30 -b:v 0 -crf 30 -threads 4 -strict experimental"
 opus := "libopus -ar 48000 -ac 2 -b:a 48k -application voip -frame_duration 10 -vbr constrained"
 
 gst_hd := "video/x-raw,format=I420,width=1280,height=720,framerate=30/1"
@@ -271,6 +272,11 @@ ffmpeg-rtp-vp8:
 ffmpeg-rtp-vp9:
     cargo run --bin=whipinto -- -i {{isdp}} -w {{server}}/whip/{{stream}} --command \
         "ffmpeg -re {{vsrc}} -strict experimental -vcodec {{vp9}} -f rtp rtp://{{host}}:5002 -sdp_file {{isdp}}"
+
+[group('simple-rtp')]
+ffmpeg-rtp-av1:
+    cargo run --bin=whipinto -- -i {{isdp}} -w {{server}}/whip/{{stream}} --command \
+        "ffmpeg -re {{vsrc}} -vcodec {{av1}} -f rtp rtp://{{host}}:5002 -sdp_file {{isdp}}"
 
 # 4K (3840×2160)
 [group('simple-rtp')]

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ h264 := "libx264 -pix_fmt yuv420p -g 60 -keyint_min 60 -crf 23 -preset ultrafast
 h265 := "libx265 -pix_fmt yuv420p -g 60 -keyint_min 60 -crf 25 -preset ultrafast -tune zerolatency -profile:v main -level 4.1"
 vp8  := "libvpx -pix_fmt yuv420p -g 60 -keyint_min 60 -deadline realtime -speed 4 -b:v 2000k -maxrate 2500k -bufsize 5000k"
 vp9  := "libvpx-vp9 -pix_fmt yuv420p -g 60 -keyint_min 60 -deadline realtime -speed 5 -row-mt 1 -tile-columns 2 -frame-parallel 1 -b:v 1800k -maxrate 2200k -bufsize 4400k"
-av1  := "libaom-av1 -cpu-used 8 -tile-columns 0 -tile-rows 0 -row-mt 1 -lag-in-frames 0 -g 30 -keyint_min 30 -b:v 0 -crf 30 -threads 4 -strict experimental"
+av1  := "libaom-av1 -pix_fmt yuv420p -cpu-used 8 -tile-columns 0 -tile-rows 0 -row-mt 1 -lag-in-frames 0 -g 30 -keyint_min 30 -b:v 0 -crf 30 -threads 4 -strict experimental"
 opus := "libopus -ar 48000 -ac 2 -b:a 48k -application voip -frame_duration 10 -vbr constrained"
 
 gst_hd := "video/x-raw,format=I420,width=1280,height=720,framerate=30/1"

--- a/libs/rtsp/Cargo.toml
+++ b/libs/rtsp/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["lib"]
 
 [dependencies]
 anyhow = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["io-util", "net", "rt", "macros"] }
 tracing = { workspace = true }
 base64 = { workspace = true }
 

--- a/libs/rtsp/src/sdp.rs
+++ b/libs/rtsp/src/sdp.rs
@@ -94,6 +94,10 @@ fn parse_video_codec(media: &sdp_types::Media) -> Option<VideoCodecParams> {
             payload_type,
             clock_rate,
         }),
+        "AV1" => Some(VideoCodecParams::AV1 {
+            payload_type,
+            clock_rate,
+        }),
         _ => {
             warn!("Unsupported video codec: {}", codec_name);
             None
@@ -435,6 +439,33 @@ a=rtpmap:96 VP8/90000
             assert_eq!(clock_rate, 90000);
         } else {
             panic!("Expected VP8 codec");
+        }
+    }
+
+    #[test]
+    fn test_parse_video_codec_av1() {
+        let sdp = r#"v=0
+o=- 0 0 IN IP4 127.0.0.1
+s=Test
+c=IN IP4 127.0.0.1
+t=0 0
+m=video 5004 RTP/AVP 96
+a=rtpmap:96 AV1/90000
+"#;
+
+        let session = sdp_types::Session::parse(sdp.as_bytes()).unwrap();
+        let codec = parse_video_codec(&session.medias[0]);
+
+        assert!(codec.is_some());
+        if let Some(VideoCodecParams::AV1 {
+            payload_type,
+            clock_rate,
+        }) = codec
+        {
+            assert_eq!(payload_type, 96);
+            assert_eq!(clock_rate, 90000);
+        } else {
+            panic!("Expected AV1 codec");
         }
     }
 

--- a/libs/rtsp/src/types/mod.rs
+++ b/libs/rtsp/src/types/mod.rs
@@ -75,6 +75,10 @@ pub enum VideoCodecParams {
         payload_type: u8,
         clock_rate: u32,
     },
+    AV1 {
+        payload_type: u8,
+        clock_rate: u32,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -168,6 +172,14 @@ impl CodecFingerprint {
             VideoCodecParams::VP9 { clock_rate, .. } => Self {
                 kind: MediaKind::Video,
                 mime_type: normalize_mime_type("video/VP9"),
+                clock_rate: *clock_rate,
+                channels: None,
+                fmtp: Some(normalize_fmtp("profile-id=0")),
+                codec_private_hash: None,
+            },
+            VideoCodecParams::AV1 { clock_rate, .. } => Self {
+                kind: MediaKind::Video,
+                mime_type: normalize_mime_type("video/AV1"),
                 clock_rate: *clock_rate,
                 channels: None,
                 fmtp: Some(normalize_fmtp("profile-id=0")),
@@ -312,6 +324,10 @@ impl From<cli::Codec> for VideoCodecParams {
                 payload_type: 96,
                 clock_rate: 90000,
             },
+            cli::Codec::AV1 => VideoCodecParams::AV1 {
+                payload_type: 96,
+                clock_rate: 90000,
+            },
             _ => VideoCodecParams::H264 {
                 payload_type: 96,
                 clock_rate: 90000,
@@ -395,6 +411,15 @@ impl From<VideoCodecParams> for rtc::rtp_transceiver::rtp_sender::RTCRtpCodec {
             VideoCodecParams::VP9 { clock_rate, .. } => {
                 rtc::rtp_transceiver::rtp_sender::RTCRtpCodec {
                     mime_type: "video/VP9".to_string(),
+                    clock_rate,
+                    channels: 0,
+                    sdp_fmtp_line: "profile-id=0".to_string(),
+                    rtcp_feedback: video_rtcp_feedback(),
+                }
+            }
+            VideoCodecParams::AV1 { clock_rate, .. } => {
+                rtc::rtp_transceiver::rtp_sender::RTCRtpCodec {
+                    mime_type: "video/AV1".to_string(),
                     clock_rate,
                     channels: 0,
                     sdp_fmtp_line: "profile-id=0".to_string(),
@@ -651,6 +676,10 @@ mod tests {
                 vps: vec![],
                 sps: vec![],
                 pps: vec![],
+            },
+            VideoCodecParams::AV1 {
+                payload_type: 96,
+                clock_rate: 90000,
             },
         ];
 

--- a/liveion/src/forward/av1_repacketizer.rs
+++ b/liveion/src/forward/av1_repacketizer.rs
@@ -65,14 +65,14 @@ impl Av1Repacketizer {
     pub fn process(&mut self, packet: &Packet) -> Result<Vec<Packet>> {
         // Detect sequence number gaps.  AV1 depacketization is stateful, so a
         // missing packet makes the current accumulator unusable.
-        if let Some(expected) = self.expected_seq {
-            if packet.header.sequence_number != expected {
-                warn!(
-                    "AV1 RTP sequence gap detected: expected {}, got {}; resetting assembler",
-                    expected, packet.header.sequence_number
-                );
-                self.reset();
-            }
+        if let Some(expected) = self.expected_seq
+            && packet.header.sequence_number != expected
+        {
+            warn!(
+                "AV1 RTP sequence gap detected: expected {}, got {}; resetting assembler",
+                expected, packet.header.sequence_number
+            );
+            self.reset();
         }
         self.expected_seq = Some(packet.header.sequence_number.wrapping_add(1));
 

--- a/liveion/src/forward/av1_repacketizer.rs
+++ b/liveion/src/forward/av1_repacketizer.rs
@@ -116,7 +116,11 @@ impl Av1Repacketizer {
 
         // A temporal unit is complete when the RTP marker bit is set and the
         // last OBU does not continue into the next packet (Y flag is false).
-        if packet.header.marker && !self.depacketizer.y {
+        if packet.header.marker && self.depacketizer.y {
+            warn!("AV1 RTP marker set but last OBU continues (Y=1); malformed packet, dropping");
+            return Ok(Vec::new());
+        }
+        if packet.header.marker {
             if self.accumulator.is_empty() {
                 debug!("AV1 marker received but accumulator is empty");
                 return Ok(Vec::new());

--- a/liveion/src/forward/av1_repacketizer.rs
+++ b/liveion/src/forward/av1_repacketizer.rs
@@ -23,7 +23,7 @@ const MAX_TEMPORAL_UNIT_SIZE: usize = 8 * 1024 * 1024;
 /// after SRTP/DTLS/ICE overhead.
 const AV1_OUTGOING_MTU: usize = 1200;
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Av1Repacketizer {
     depacketizer: Av1Depacketizer,
     payloader: Av1Payloader,
@@ -43,7 +43,7 @@ impl Av1Repacketizer {
         Self {
             depacketizer: Av1Depacketizer::new(),
             payloader: Av1Payloader::default(),
-            accumulator: BytesMut::new(),
+            accumulator: BytesMut::with_capacity(128 * 1024),
             expected_seq: None,
             last_timestamp: 0,
         }
@@ -77,7 +77,8 @@ impl Av1Repacketizer {
         self.expected_seq = Some(packet.header.sequence_number.wrapping_add(1));
 
         // Timestamp discontinuity also indicates a new temporal unit or lost
-        // stream state.
+        // stream state.  We do not check SSRC here — RTP-level stream
+        // multiplexing is handled by the higher-level bridge and track layers.
         if self.last_timestamp != 0 && packet.header.timestamp != self.last_timestamp {
             if !self.accumulator.is_empty() {
                 warn!(
@@ -118,6 +119,7 @@ impl Av1Repacketizer {
         // last OBU does not continue into the next packet (Y flag is false).
         if packet.header.marker && self.depacketizer.y {
             warn!("AV1 RTP marker set but last OBU continues (Y=1); malformed packet, dropping");
+            self.reset();
             return Ok(Vec::new());
         }
         if packet.header.marker {

--- a/liveion/src/forward/av1_repacketizer.rs
+++ b/liveion/src/forward/av1_repacketizer.rs
@@ -1,0 +1,328 @@
+//! AV1 RTP repacketizer for `whipinto` sources.
+//!
+//! Incoming AV1 RTP packets from external tools (ffmpeg, gstreamer, etc.) may be
+//! larger than the WebRTC 1200-byte MTU (e.g. ffmpeg defaults to 1472).  This
+//! module depacketizes the AV1 RTP stream into OBU bitstream and repacketizes
+//! it with a smaller MTU before it reaches the WebRTC subscriber path.
+
+use anyhow::{Context, Result};
+use bytes::BytesMut;
+use rtc_rtp::codec::av1::{Av1Depacketizer, Av1Payloader};
+use rtc_rtp::packet::Packet;
+use rtc_rtp::packetizer::{Depacketizer, Payloader};
+use tracing::{debug, trace, warn};
+
+/// Maximum accumulated temporal unit size.  Resets the assembler if a single
+/// temporal unit grows beyond this, to avoid unbounded memory growth on packet
+/// loss or malformed streams.
+const MAX_TEMPORAL_UNIT_SIZE: usize = 8 * 1024 * 1024;
+
+/// Target RTP payload size for repacketized AV1 packets.
+///
+/// WebRTC typically requires the full UDP datagram to stay under ~1200 bytes
+/// after SRTP/DTLS/ICE overhead.
+const AV1_OUTGOING_MTU: usize = 1200;
+
+#[derive(Debug, Clone)]
+pub struct Av1Repacketizer {
+    depacketizer: Av1Depacketizer,
+    payloader: Av1Payloader,
+    accumulator: BytesMut,
+    expected_seq: Option<u16>,
+    last_timestamp: u32,
+}
+
+impl Default for Av1Repacketizer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Av1Repacketizer {
+    pub fn new() -> Self {
+        Self {
+            depacketizer: Av1Depacketizer::new(),
+            payloader: Av1Payloader::default(),
+            accumulator: BytesMut::new(),
+            expected_seq: None,
+            last_timestamp: 0,
+        }
+    }
+
+    /// Reset internal state, e.g. after packet loss or a parse error.
+    fn reset(&mut self) {
+        self.depacketizer = Av1Depacketizer::new();
+        self.accumulator.clear();
+        self.expected_seq = None;
+        self.last_timestamp = 0;
+    }
+
+    /// Process one incoming AV1 RTP packet and return zero or more repacketized
+    /// RTP packets whose payloads are at most [`AV1_OUTGOING_MTU`] bytes.
+    ///
+    /// Sequence numbers in returned packets are placeholders and are rewritten
+    /// later by `VirtualPublishTrack::inject_rtp`.
+    pub fn process(&mut self, packet: &Packet) -> Result<Vec<Packet>> {
+        // Detect sequence number gaps.  AV1 depacketization is stateful, so a
+        // missing packet makes the current accumulator unusable.
+        if let Some(expected) = self.expected_seq {
+            if packet.header.sequence_number != expected {
+                warn!(
+                    "AV1 RTP sequence gap detected: expected {}, got {}; resetting assembler",
+                    expected, packet.header.sequence_number
+                );
+                self.reset();
+            }
+        }
+        self.expected_seq = Some(packet.header.sequence_number.wrapping_add(1));
+
+        // Timestamp discontinuity also indicates a new temporal unit or lost
+        // stream state.
+        if self.last_timestamp != 0 && packet.header.timestamp != self.last_timestamp {
+            if !self.accumulator.is_empty() {
+                warn!(
+                    "AV1 RTP timestamp discontinuity ({} -> {}); dropping incomplete temporal unit",
+                    self.last_timestamp, packet.header.timestamp
+                );
+            }
+            self.reset();
+        }
+        self.last_timestamp = packet.header.timestamp;
+
+        let obus = self
+            .depacketizer
+            .depacketize(&packet.payload)
+            .with_context(|| "AV1 depacketization failed")?;
+
+        trace!(
+            "AV1 depacketized: seq={} marker={} y={} len={}",
+            packet.header.sequence_number,
+            packet.header.marker,
+            self.depacketizer.y,
+            obus.len()
+        );
+
+        if !obus.is_empty() {
+            if self.accumulator.len() + obus.len() > MAX_TEMPORAL_UNIT_SIZE {
+                warn!(
+                    "AV1 temporal unit exceeded maximum size ({} bytes); resetting assembler",
+                    MAX_TEMPORAL_UNIT_SIZE
+                );
+                self.reset();
+                return Ok(Vec::new());
+            }
+            self.accumulator.extend_from_slice(&obus);
+        }
+
+        // A temporal unit is complete when the RTP marker bit is set and the
+        // last OBU does not continue into the next packet (Y flag is false).
+        if packet.header.marker && !self.depacketizer.y {
+            if self.accumulator.is_empty() {
+                debug!("AV1 marker received but accumulator is empty");
+                return Ok(Vec::new());
+            }
+
+            let accumulated = std::mem::take(&mut self.accumulator).freeze();
+            let payloads = self
+                .payloader
+                .payload(AV1_OUTGOING_MTU, &accumulated)
+                .with_context(|| "AV1 repacketization failed")?;
+
+            let total = payloads.len();
+            let mut output = Vec::with_capacity(total);
+
+            for (idx, payload) in payloads.into_iter().enumerate() {
+                let mut header = packet.header.clone();
+                header.marker = idx == total - 1;
+                header.sequence_number = 0; // rewritten by VirtualPublishTrack
+                header.padding = false;
+                header.extension = false;
+                header.extension_profile = 0;
+                header.extensions.clear();
+                header.extensions_padding = 0;
+
+                output.push(Packet { header, payload });
+            }
+
+            trace!(
+                "AV1 repacketized: seq={} timestamp={} {} packets, last_marker={}",
+                packet.header.sequence_number,
+                packet.header.timestamp,
+                output.len(),
+                output.last().map(|p| p.header.marker).unwrap_or(false)
+            );
+
+            return Ok(output);
+        }
+
+        Ok(Vec::new())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use rtc_rtp::header::Header;
+
+    /// Build a minimal AV1 OBU: Frame OBU (type=6) without extension and without
+    /// size field, followed by payload bytes.
+    fn build_av1_obu(payload: &[u8]) -> Bytes {
+        let mut obu = BytesMut::with_capacity(1 + payload.len());
+        // OBU header: type=6 (Frame), has_size=0, extension=0 -> 0x30
+        obu.extend_from_slice(&[0x30]);
+        obu.extend_from_slice(payload);
+        obu.freeze()
+    }
+
+    /// Build an AV1 RTP packet using the AV1 OBU aggregation format.
+    /// Aggregation header: W=1, no Z, no Y, no N -> 0x10
+    fn build_av1_rtp_packet(seq: u16, timestamp: u32, marker: bool, obu: &[u8]) -> Packet {
+        let mut payload = BytesMut::with_capacity(1 + obu.len());
+        payload.extend_from_slice(&[0x10]); // aggregation header
+        payload.extend_from_slice(obu);
+
+        Packet {
+            header: Header {
+                version: 2,
+                marker,
+                payload_type: 96,
+                sequence_number: seq,
+                timestamp,
+                ssrc: 0x12345678,
+                ..Default::default()
+            },
+            payload: payload.freeze(),
+        }
+    }
+
+    #[test]
+    fn repacketize_single_oversized_temporal_unit() {
+        // Create a temporal unit larger than 1200 bytes.
+        let obu = build_av1_obu(&[0xAB; 3000]);
+        let packet = build_av1_rtp_packet(1, 1000, true, &obu);
+
+        let mut repacketizer = Av1Repacketizer::new();
+        let output = repacketizer
+            .process(&packet)
+            .expect("process should succeed");
+
+        assert!(
+            !output.is_empty(),
+            "oversized AV1 temporal unit should be split"
+        );
+
+        // Every output payload must be <= 1200 bytes.
+        for (i, pkt) in output.iter().enumerate() {
+            assert!(
+                pkt.payload.len() <= AV1_OUTGOING_MTU,
+                "packet {} payload {} exceeds MTU",
+                i,
+                pkt.payload.len()
+            );
+        }
+
+        // Only the last packet should have the marker bit set.
+        assert!(output.last().unwrap().header.marker);
+        for pkt in output.iter().take(output.len() - 1) {
+            assert!(!pkt.header.marker);
+        }
+
+        // Timestamps and SSRC should be preserved.
+        for pkt in &output {
+            assert_eq!(pkt.header.timestamp, 1000);
+            assert_eq!(pkt.header.ssrc, 0x12345678);
+            assert_eq!(pkt.header.payload_type, 96);
+        }
+    }
+
+    #[test]
+    fn fragmented_temporal_unit_is_reassembled_before_repacketization() {
+        // Split a large OBU across two RTP packets using the AV1 Z/Y fragmentation
+        // flags with W=1 (single OBU element, no length field).
+        let obu = build_av1_obu(&[0xCD; 3000]);
+        let split_at = 1501; // includes the 1-byte OBU header
+        let first_fragment = &obu[..split_at];
+        let second_fragment = &obu[split_at..];
+
+        // First packet: W=1, Y=1 (last OBU continues), marker=false.
+        // Aggregation header: 0x50 (W=1, Y=1)
+        let mut payload1 = BytesMut::with_capacity(1 + first_fragment.len());
+        payload1.extend_from_slice(&[0x50]);
+        payload1.extend_from_slice(first_fragment);
+        let packet1 = Packet {
+            header: Header {
+                version: 2,
+                marker: false,
+                payload_type: 96,
+                sequence_number: 10,
+                timestamp: 2000,
+                ssrc: 0x12345678,
+                ..Default::default()
+            },
+            payload: payload1.freeze(),
+        };
+
+        // Second packet: Z=1 (continuation), Y=0, marker=true.
+        // Aggregation header: 0x90 (Z=1, W=1)
+        let mut payload2 = BytesMut::with_capacity(1 + second_fragment.len());
+        payload2.extend_from_slice(&[0x90]);
+        payload2.extend_from_slice(second_fragment);
+        let packet2 = Packet {
+            header: Header {
+                version: 2,
+                marker: true,
+                payload_type: 96,
+                sequence_number: 11,
+                timestamp: 2000,
+                ssrc: 0x12345678,
+                ..Default::default()
+            },
+            payload: payload2.freeze(),
+        };
+
+        let mut repacketizer = Av1Repacketizer::new();
+        let out1 = repacketizer
+            .process(&packet1)
+            .expect("process should succeed");
+        assert!(
+            out1.is_empty(),
+            "incomplete temporal unit yields no packets"
+        );
+
+        let out2 = repacketizer
+            .process(&packet2)
+            .expect("process should succeed");
+        assert!(!out2.is_empty(), "complete temporal unit should be split");
+
+        for (i, pkt) in out2.iter().enumerate() {
+            assert!(
+                pkt.payload.len() <= AV1_OUTGOING_MTU,
+                "packet {} payload {} exceeds MTU",
+                i,
+                pkt.payload.len()
+            );
+        }
+        assert!(out2.last().unwrap().header.marker);
+    }
+
+    #[test]
+    fn sequence_gap_resets_assembler() {
+        let obu = build_av1_obu(&[0xEF; 100]);
+        let packet1 = build_av1_rtp_packet(1, 1000, false, &obu);
+        // Gap: seq 2 is missing. packet2 is a complete temporal unit on its own.
+        let packet2 = build_av1_rtp_packet(3, 1000, true, &obu);
+
+        let mut repacketizer = Av1Repacketizer::new();
+        let out1 = repacketizer.process(&packet1).unwrap();
+        assert!(out1.is_empty());
+
+        // Gap triggers reset; packet2 is processed as a new, complete temporal unit.
+        let out2 = repacketizer.process(&packet2).unwrap();
+        assert!(
+            !out2.is_empty(),
+            "gap should reset state and allow the new complete unit to be emitted"
+        );
+        assert!(out2.last().unwrap().header.marker);
+    }
+}

--- a/liveion/src/forward/bridge.rs
+++ b/liveion/src/forward/bridge.rs
@@ -183,13 +183,17 @@ impl SourceBridge {
             let mut audio_count = 0u64;
             #[cfg(not(any(feature = "source-rtsp", feature = "source-sdp")))]
             let audio_count = 0u64;
+            #[cfg(any(feature = "source-rtsp", feature = "source-sdp"))]
+            let mut video_dropped = 0u64;
+            #[cfg(not(any(feature = "source-rtsp", feature = "source-sdp")))]
+            let video_dropped = 0u64;
 
             loop {
                 tokio::select! {
                     _ = shutdown_rx1.recv() => {
                         info!(
-                            "[{}] RTP task shutting down, forwarded {} packets (video: {}, audio: {})",
-                            source_id_clone, packet_count, video_count, audio_count
+                            "[{}] RTP task shutting down, forwarded {} packets (video: {}, audio: {}, dropped: {})",
+                            source_id_clone, packet_count, video_count, audio_count, video_dropped
                         );
                         break;
                     }
@@ -233,12 +237,14 @@ impl SourceBridge {
                                                                 Ok(())
                                                             }
                                                             Err(e) => {
+                                                                video_dropped += 1;
                                                                 warn!("[{}] AV1 repacketization failed, dropping packet: {}", source_id_clone, e);
                                                                 Ok(())
                                                             }
                                                         }
                                                     }
                                                     Err(e) => {
+                                                        video_dropped += 1;
                                                         warn!("[{}] Failed to unmarshal AV1 RTP packet, dropping: {}", source_id_clone, e);
                                                         Ok(())
                                                     }

--- a/liveion/src/forward/bridge.rs
+++ b/liveion/src/forward/bridge.rs
@@ -1,10 +1,13 @@
 use super::PeerForward;
+use crate::forward::av1_repacketizer::Av1Repacketizer;
 use crate::forward::rtcp::RtcpMessage;
 use crate::stream::source::{MediaPacket, StateChangeEvent};
 use anyhow::Result;
 #[cfg(any(feature = "source-rtsp", feature = "source-sdp"))]
 use anyhow::anyhow;
-use rtc::shared::marshal::Marshal;
+use rtc::shared::marshal::{Marshal, Unmarshal};
+#[cfg(any(feature = "source-rtsp", feature = "source-sdp"))]
+use rtc_rtp::packet::Packet;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::broadcast;
@@ -80,6 +83,7 @@ pub struct SourceBridge {
     shutdown_tx: Option<tokio::sync::broadcast::Sender<()>>,
 
     channel_mapping: ChannelMapping,
+    av1_repacketizer: Option<Av1Repacketizer>,
 
     #[cfg(feature = "source")]
     rtcp_to_source_tx: Option<tokio::sync::mpsc::UnboundedSender<Vec<u8>>>,
@@ -88,8 +92,19 @@ pub struct SourceBridge {
 }
 
 impl SourceBridge {
-    pub fn new(source_id: String, forward: PeerForward, has_video: bool, has_audio: bool) -> Self {
+    pub fn new(
+        source_id: String,
+        forward: PeerForward,
+        has_video: bool,
+        has_audio: bool,
+        video_codec_name: Option<String>,
+    ) -> Self {
         let channel_mapping = ChannelMapping::new(has_video, has_audio);
+        let av1_repacketizer = video_codec_name
+            .as_deref()
+            .map(|name| name.eq_ignore_ascii_case("AV1"))
+            .unwrap_or(false)
+            .then(Av1Repacketizer::new);
 
         Self {
             source_id,
@@ -97,6 +112,7 @@ impl SourceBridge {
             tasks: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             shutdown_tx: None,
             channel_mapping,
+            av1_repacketizer,
             #[cfg(feature = "source")]
             rtcp_to_source_tx: None,
             #[cfg(feature = "source")]
@@ -143,6 +159,7 @@ impl SourceBridge {
         let source_id_clone = self.source_id.clone();
         let mut shutdown_rx1 = shutdown_tx.subscribe();
         let channel_mapping = self.channel_mapping;
+        let mut av1_repacketizer = self.av1_repacketizer.take();
 
         let rtp_task = tokio::spawn(async move {
             info!(
@@ -203,7 +220,32 @@ impl SourceBridge {
                                                     source_id_clone, video_count, data.len()
                                                 );
                                             }
-                                            forward_clone.inject_video_rtp(&data).await.map_err(|e| anyhow!("{:?}", e))
+                                            if let Some(ref mut repacketizer) = av1_repacketizer {
+                                                match Packet::unmarshal(&mut &data[..]) {
+                                                    Ok(packet) => {
+                                                        match repacketizer.process(&packet) {
+                                                            Ok(packets) => {
+                                                                for packet in packets {
+                                                                    if let Err(e) = forward_clone.inject_video_rtp_packet(std::sync::Arc::new(packet)).await {
+                                                                        error!("[{}] Failed to inject repacketized AV1 RTP packet: {:?}", source_id_clone, e);
+                                                                    }
+                                                                }
+                                                                Ok(())
+                                                            }
+                                                            Err(e) => {
+                                                                warn!("[{}] AV1 repacketization failed, dropping packet: {}", source_id_clone, e);
+                                                                Ok(())
+                                                            }
+                                                        }
+                                                    }
+                                                    Err(e) => {
+                                                        warn!("[{}] Failed to unmarshal AV1 RTP packet, dropping: {}", source_id_clone, e);
+                                                        Ok(())
+                                                    }
+                                                }
+                                            } else {
+                                                forward_clone.inject_video_rtp(&data).await.map_err(|e| anyhow!("{:?}", e))
+                                            }
                                         } else if channel_mapping.is_audio_rtp(channel) {
                                             audio_count += 1;
                                             if audio_count % LOG_PACKET_INTERVAL == 1 {
@@ -553,5 +595,167 @@ impl Drop for SourceBridge {
         if let Some(tx) = &self.shutdown_tx {
             let _ = tx.send(());
         }
+    }
+}
+
+#[cfg(all(test, any(feature = "source-rtsp", feature = "source-sdp")))]
+mod integration_tests {
+    use super::*;
+    use crate::forward::PeerForward;
+    use bytes::BytesMut;
+    use rtc::rtp::header::Header;
+    use rtc::rtp::packet::Packet;
+    use rtc::rtp_transceiver::rtp_sender::{
+        RTCPFeedback, RTCRtpCodec, RTCRtpCodecParameters, RtpCodecKind,
+    };
+    use rtc::shared::marshal::MarshalSize;
+    use std::time::Duration;
+    use tokio::sync::broadcast;
+
+    fn build_av1_obu(payload: &[u8]) -> bytes::Bytes {
+        let mut obu = BytesMut::with_capacity(1 + payload.len());
+        obu.extend_from_slice(&[0x30]); // Frame OBU, no size field
+        obu.extend_from_slice(payload);
+        obu.freeze()
+    }
+
+    fn build_av1_rtp_packet(seq: u16, timestamp: u32, marker: bool, obu: &[u8]) -> Packet {
+        let mut payload = BytesMut::with_capacity(1 + obu.len());
+        payload.extend_from_slice(&[0x10]); // aggregation header: W=1
+        payload.extend_from_slice(obu);
+
+        Packet {
+            header: Header {
+                version: 2,
+                marker,
+                payload_type: 96,
+                sequence_number: seq,
+                timestamp,
+                ssrc: 0xDEADBEEF,
+                ..Default::default()
+            },
+            payload: payload.freeze(),
+        }
+    }
+
+    #[tokio::test]
+    async fn bridge_repacketizes_oversized_av1_rtp() {
+        let forward = PeerForward::new(
+            "av1-repacketizer-test",
+            vec![],
+            vec![],
+            #[cfg(feature = "source")]
+            None,
+            api::strategy::Strategy::default(),
+        );
+
+        let codec = RTCRtpCodecParameters {
+            rtp_codec: RTCRtpCodec {
+                mime_type: "video/AV1".to_owned(),
+                clock_rate: 90000,
+                channels: 0,
+                sdp_fmtp_line: "".to_owned(),
+                rtcp_feedback: vec![
+                    RTCPFeedback {
+                        typ: "nack".to_owned(),
+                        parameter: "".to_owned(),
+                    },
+                    RTCPFeedback {
+                        typ: "nack".to_owned(),
+                        parameter: "pli".to_owned(),
+                    },
+                ],
+            },
+            payload_type: 96,
+        };
+
+        forward
+            .add_virtual_track(RtpCodecKind::Video, codec)
+            .await
+            .expect("add virtual track");
+
+        let mut track_subscribe = {
+            let tracks = forward.internal.publish_tracks.read().await;
+            let track = tracks
+                .iter()
+                .find(|t| t.kind() == RtpCodecKind::Video)
+                .expect("video track exists");
+            track.subscribe()
+        };
+
+        let mut bridge = SourceBridge::new(
+            "av1-test".to_owned(),
+            forward,
+            true,
+            false,
+            Some("AV1".to_owned()),
+        );
+
+        let (rtcp_tx, _rtcp_rx) = tokio::sync::mpsc::unbounded_channel::<Vec<u8>>();
+        bridge.set_rtcp_sender(rtcp_tx);
+
+        let (rtp_tx, rtp_rx) = broadcast::channel(16);
+        let (_state_tx, state_rx) = broadcast::channel(4);
+
+        bridge
+            .start_bridging(rtp_rx, state_rx)
+            .await
+            .expect("start bridging");
+
+        // Send a single AV1 temporal unit larger than 1200 bytes.
+        let obu = build_av1_obu(&[0xAB; 3000]);
+        let packet = build_av1_rtp_packet(1, 1000, true, &obu);
+        let raw_packet = {
+            let mut buf = vec![0u8; packet.marshal_size()];
+            rtc::shared::marshal::Marshal::marshal_to(&packet, &mut buf).expect("marshal packet");
+            buf
+        };
+
+        rtp_tx
+            .send(MediaPacket::Rtp {
+                channel: 0,
+                data: raw_packet.into(),
+            })
+            .expect("send rtp");
+
+        // Wait for repacketized packets to arrive on the virtual track.
+        let mut received = Vec::new();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        loop {
+            let timeout = deadline.saturating_duration_since(tokio::time::Instant::now());
+            match tokio::time::timeout(timeout, track_subscribe.recv()).await {
+                Ok(Ok(pkt)) => {
+                    let is_marker = pkt.header.marker;
+                    received.push(pkt);
+                    if is_marker {
+                        break;
+                    }
+                }
+                Ok(Err(_)) => break,
+                Err(_) => panic!("timeout waiting for repacketized AV1 packets"),
+            }
+        }
+
+        assert!(
+            !received.is_empty(),
+            "should receive repacketized AV1 packets"
+        );
+        assert!(
+            received.len() > 1,
+            "oversized temporal unit should be split into multiple packets"
+        );
+
+        for (i, pkt) in received.iter().enumerate() {
+            assert!(
+                pkt.payload.len() <= 1200,
+                "packet {} payload {} exceeds 1200 bytes",
+                i,
+                pkt.payload.len()
+            );
+        }
+
+        assert!(received.last().unwrap().header.marker);
+
+        bridge.stop().await.expect("stop bridge");
     }
 }

--- a/liveion/src/forward/mod.rs
+++ b/liveion/src/forward/mod.rs
@@ -36,6 +36,8 @@ use self::message::CascadeInfo;
 use self::message::ForwardEvent;
 
 #[cfg(feature = "source")]
+pub(crate) mod av1_repacketizer;
+#[cfg(feature = "source")]
 pub(crate) mod channel;
 mod internal;
 mod media;

--- a/liveion/src/forward/subscribe.rs
+++ b/liveion/src/forward/subscribe.rs
@@ -329,8 +329,7 @@ impl SubscribeRTCPeerConnection {
     }
 
     fn av1_profile(fmtp: &str) -> Option<String> {
-        Self::fmtp_param(fmtp, "profile-id")
-            .or_else(|| Self::fmtp_param(fmtp, "profile"))
+        Self::fmtp_param(fmtp, "profile-id").or_else(|| Self::fmtp_param(fmtp, "profile"))
     }
 
     fn av1_codecs_are_compatible(candidate: &RTCRtpCodec, publisher: &RTCRtpCodec) -> bool {

--- a/liveion/src/forward/subscribe.rs
+++ b/liveion/src/forward/subscribe.rs
@@ -324,12 +324,43 @@ impl SubscribeRTCPeerConnection {
         true
     }
 
+    fn is_av1_codec(codec: &RTCRtpCodec) -> bool {
+        codec.mime_type.eq_ignore_ascii_case("video/AV1")
+    }
+
+    fn av1_profile(fmtp: &str) -> Option<String> {
+        Self::fmtp_param(fmtp, "profile-id")
+            .or_else(|| Self::fmtp_param(fmtp, "profile"))
+    }
+
+    fn av1_codecs_are_compatible(candidate: &RTCRtpCodec, publisher: &RTCRtpCodec) -> bool {
+        if !Self::is_av1_codec(candidate) || !Self::is_av1_codec(publisher) {
+            return false;
+        }
+
+        if candidate.clock_rate != publisher.clock_rate || candidate.channels != publisher.channels
+        {
+            return false;
+        }
+
+        match (
+            Self::av1_profile(&publisher.sdp_fmtp_line),
+            Self::av1_profile(&candidate.sdp_fmtp_line),
+        ) {
+            (Some(publisher_profile), Some(candidate_profile)) => {
+                publisher_profile == candidate_profile
+            }
+            _ => true,
+        }
+    }
+
     fn sender_track_codec_compatible(
         sender_track_codec: &RTCRtpCodec,
         selected_codec: &RTCRtpCodec,
     ) -> bool {
         Self::rtp_codecs_match(sender_track_codec, selected_codec)
             || Self::h265_codecs_are_compatible(sender_track_codec, selected_codec)
+            || Self::av1_codecs_are_compatible(sender_track_codec, selected_codec)
     }
 
     async fn select_sender_codec(
@@ -401,6 +432,15 @@ impl SubscribeRTCPeerConnection {
                 .iter()
                 .find(|candidate| {
                     Self::h265_codecs_are_compatible(&candidate.rtp_codec, publisher_codec)
+                })
+                .cloned();
+        }
+
+        if Self::is_av1_codec(publisher_codec) {
+            return codecs
+                .iter()
+                .find(|candidate| {
+                    Self::av1_codecs_are_compatible(&candidate.rtp_codec, publisher_codec)
                 })
                 .cloned();
         }
@@ -1026,5 +1066,92 @@ mod tests {
             )
             .is_none()
         );
+    }
+
+    #[test]
+    fn av1_codec_selection_prefers_matching_profile() {
+        let source_codec = RTCRtpCodec {
+            mime_type: "video/AV1".to_string(),
+            clock_rate: 90000,
+            channels: 0,
+            sdp_fmtp_line: "profile-id=0;level-idx=5;tier=0".to_string(),
+            rtcp_feedback: vec![],
+        };
+        let profile_1 = RTCRtpCodecParameters {
+            rtp_codec: RTCRtpCodec {
+                mime_type: "video/AV1".to_string(),
+                clock_rate: 90000,
+                channels: 0,
+                sdp_fmtp_line: "profile=1;level-idx=5;tier=0".to_string(),
+                rtcp_feedback: vec![],
+            },
+            payload_type: 47,
+        };
+        let profile_0 = RTCRtpCodecParameters {
+            rtp_codec: RTCRtpCodec {
+                mime_type: "video/AV1".to_string(),
+                clock_rate: 90000,
+                channels: 0,
+                sdp_fmtp_line: "profile-id=0;level-idx=5;tier=0".to_string(),
+                rtcp_feedback: vec![],
+            },
+            payload_type: 41,
+        };
+
+        let selected = SubscribeRTCPeerConnection::select_compatible_codec(
+            RtpCodecKind::Video,
+            &source_codec,
+            &[profile_1, profile_0],
+        )
+        .expect("matching AV1 profile should be selected");
+
+        assert_eq!(selected.payload_type, 41);
+        assert!(selected.rtp_codec.sdp_fmtp_line.contains("profile-id=0"));
+    }
+
+    #[test]
+    fn av1_codecs_with_mismatched_profile_are_incompatible() {
+        let sender_track_codec = RTCRtpCodec {
+            mime_type: "video/AV1".to_string(),
+            clock_rate: 90000,
+            channels: 0,
+            sdp_fmtp_line: "profile-id=0;level-idx=5;tier=0".to_string(),
+            rtcp_feedback: vec![],
+        };
+        let selected_codec = RTCRtpCodec {
+            mime_type: "video/AV1".to_string(),
+            clock_rate: 90000,
+            channels: 0,
+            sdp_fmtp_line: "profile=1;level-idx=5;tier=0".to_string(),
+            rtcp_feedback: vec![],
+        };
+
+        assert!(!SubscribeRTCPeerConnection::sender_track_codec_compatible(
+            &sender_track_codec,
+            &selected_codec
+        ));
+    }
+
+    #[test]
+    fn av1_codecs_with_matching_profile_are_compatible() {
+        let sender_track_codec = RTCRtpCodec {
+            mime_type: "video/AV1".to_string(),
+            clock_rate: 90000,
+            channels: 0,
+            sdp_fmtp_line: "profile-id=0;level-idx=5;tier=0".to_string(),
+            rtcp_feedback: vec![],
+        };
+        let selected_codec = RTCRtpCodec {
+            mime_type: "video/AV1".to_string(),
+            clock_rate: 90000,
+            channels: 0,
+            sdp_fmtp_line: "profile=0;level-idx=8;tier=0".to_string(),
+            rtcp_feedback: vec![],
+        };
+
+        assert!(SubscribeRTCPeerConnection::sender_track_codec_compatible(
+            &sender_track_codec,
+            &selected_codec
+        ));
     }
 }

--- a/liveion/src/stream/source/manager.rs
+++ b/liveion/src/stream/source/manager.rs
@@ -141,6 +141,13 @@ impl SourceManager {
 
         let has_video = video_codec.is_some();
         let has_audio = audio_codec.is_some();
+        let video_codec_name = video_codec.as_ref().and_then(|c| {
+            c.rtp_codec
+                .mime_type
+                .split('/')
+                .nth(1)
+                .map(|s| s.to_string())
+        });
 
         if let Some(codec) = video_codec {
             info!(
@@ -198,7 +205,13 @@ impl SourceManager {
 
         drop(source_guard);
 
-        let mut bridge = SourceBridge::new(stream_id.to_string(), forward, has_video, has_audio);
+        let mut bridge = SourceBridge::new(
+            stream_id.to_string(),
+            forward,
+            has_video,
+            has_audio,
+            video_codec_name,
+        );
 
         if let Some(rtcp_tx) = rtcp_sender {
             bridge.set_rtcp_sender(rtcp_tx);

--- a/liveion/src/stream/source/rtsp_source.rs
+++ b/liveion/src/stream/source/rtsp_source.rs
@@ -556,6 +556,40 @@ impl RtspSource {
                 },
                 payload_type: *payload_type,
             },
+            VideoCodecParams::AV1 {
+                payload_type,
+                clock_rate,
+            } => RTCRtpCodecParameters {
+                rtp_codec: RTCRtpCodec {
+                    mime_type: "video/AV1".to_string(),
+                    clock_rate: *clock_rate,
+                    channels: 0,
+                    sdp_fmtp_line: "profile-id=0".to_string(),
+                    rtcp_feedback: vec![
+                        RTCPFeedback {
+                            typ: "goog-remb".to_owned(),
+                            parameter: "".to_owned(),
+                        },
+                        RTCPFeedback {
+                            typ: "transport-cc".to_owned(),
+                            parameter: "".to_owned(),
+                        },
+                        RTCPFeedback {
+                            typ: "ccm".to_owned(),
+                            parameter: "fir".to_owned(),
+                        },
+                        RTCPFeedback {
+                            typ: "nack".to_owned(),
+                            parameter: "".to_owned(),
+                        },
+                        RTCPFeedback {
+                            typ: "nack".to_owned(),
+                            parameter: "pli".to_owned(),
+                        },
+                    ],
+                },
+                payload_type: *payload_type,
+            },
         }
     }
 

--- a/livetwo/src/payload/repayload.rs
+++ b/livetwo/src/payload/repayload.rs
@@ -106,6 +106,8 @@ impl RePayloadCodec {
             Box::<h264::H264Packet>::default()
         } else if is(MIME_TYPE_HEVC) {
             Box::<h265::H265Packet>::default()
+        } else if is(MIME_TYPE_AV1) {
+            Box::<av1::Av1Depacketizer>::default()
         } else if is(MIME_TYPE_OPUS) {
             Box::<opus::OpusPacket>::default()
         } else {
@@ -120,6 +122,8 @@ impl RePayloadCodec {
             Box::<h264::H264Payloader>::default()
         } else if is(MIME_TYPE_HEVC) {
             Box::<h265::HevcPayloader>::default()
+        } else if is(MIME_TYPE_AV1) {
+            Box::<av1::Av1Payloader>::default()
         } else if is(MIME_TYPE_OPUS) {
             Box::<opus::OpusPayloader>::default()
         } else {

--- a/livetwo/src/whip/track.rs
+++ b/livetwo/src/whip/track.rs
@@ -109,7 +109,7 @@ pub async fn setup_video_track(
         let mut first_write = true;
 
         let mut handler: Box<dyn RePayload + Send> = match video_codec.mime_type.as_str() {
-            MIME_TYPE_VP8 | MIME_TYPE_VP9 => {
+            MIME_TYPE_VP8 | MIME_TYPE_VP9 | MIME_TYPE_AV1 => {
                 Box::new(RePayloadCodec::new(video_codec.mime_type.clone()))
             }
             MIME_TYPE_H264 => {


### PR DESCRIPTION
Close #338

This PR enables whipinto to accept AV1 streams whose input RTP packets are larger than the WebRTC 1200-byte MTU (e.g. ffmpeg defaults to 1472).

Changes:
- Add Av1Repacketizer in liveion/src/forward/av1_repacketizer.rs to depacketize incoming AV1 RTP packets and repacketize them into <=1200 byte payloads.
- Wire the repacketizer into SourceBridge for the source-sdp / source-rtsp paths.
- Add unit tests for oversized temporal units, fragmented OBUs, and sequence-gap handling.
- Add an integration test through SourceBridge verifying oversized AV1 RTP is split into <=1200 byte packets.
- Update documentation: AV1 is now marked as supporting pkt_size > 1200.
- Add ffmpeg-rtp-av1 recipe to the justfile.
- Fix libs/rtsp/Cargo.toml tokio features so source-sdp / source-rtsp features compile.