### PR TITLE
fix: WebRTC/RTP improvements across stack

### DIFF
--- a/libs/rtsp/src/types/mod.rs
+++ b/libs/rtsp/src/types/mod.rs
@@ -480,7 +480,7 @@ impl From<AudioCodecParams> for rtc::rtp_transceiver::rtp_sender::RTCRtpCodec {
             mime_type: format!("audio/{}", params.codec),
             clock_rate: params.clock_rate,
             channels: params.channels,
-            sdp_fmtp_line: if params.codec == "opus" {
+            sdp_fmtp_line: if params.codec.eq_ignore_ascii_case("opus") {
                 "minptime=10;useinbandfec=1".to_string()
             } else {
                 "".to_string()

--- a/livecam/src/whep_handler.rs
+++ b/livecam/src/whep_handler.rs
@@ -7,6 +7,7 @@ use axum::{
     response::{IntoResponse, Response},
     routing::{delete, options, patch, post},
 };
+use rtc::ice::mdns::MulticastDnsMode;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Notify;
@@ -115,6 +116,7 @@ async fn whep_handler(
     debug!(stream_id, "Media engine initialized with default codecs.");
 
     let mut setting_engine = SettingEngine::default();
+    setting_engine.set_multicast_dns_mode(MulticastDnsMode::Disabled);
     setting_engine.set_ice_timeouts(
         Some(Duration::from_secs(15)),
         Some(Duration::from_secs(30)),

--- a/liveion/src/forward/internal.rs
+++ b/liveion/src/forward/internal.rs
@@ -18,6 +18,7 @@ use crate::forward::message::{ForwardInfo, SessionInfo};
 use crate::forward::rtcp::RtcpMessage;
 use crate::result::Result;
 use crate::{metrics, new_broadcast_channel};
+use rtc::ice::mdns::MulticastDnsMode;
 use rtc::peer_connection::configuration::interceptor_registry::{
     configure_nack, configure_rtcp_reports, configure_simulcast_extension_headers,
     configure_twcc_receiver_only, configure_twcc_sender_only,
@@ -1221,7 +1222,8 @@ impl PeerForwardInternal {
         });
         *self.rtcp_egress_counters.lock().unwrap() = Some(egress_counters);
 
-        let s = SettingEngine::default();
+        let mut s = SettingEngine::default();
+        s.set_multicast_dns_mode(MulticastDnsMode::Disabled);
 
         let ice_servers = self.ice_server.clone();
         info!(
@@ -1418,7 +1420,8 @@ impl PeerForwardInternal {
         configure_simulcast_extension_headers(&mut m)?;
         let registry = configure_twcc_sender_only(registry, &mut m)?;
 
-        let s = SettingEngine::default();
+        let mut s = SettingEngine::default();
+        s.set_multicast_dns_mode(MulticastDnsMode::Disabled);
 
         let ice_servers = self.ice_server.clone();
         info!(

--- a/liveion/src/forward/subscribe.rs
+++ b/liveion/src/forward/subscribe.rs
@@ -436,6 +436,7 @@ impl SubscribeRTCPeerConnection {
         let message = err.to_string();
         message.contains("local_srtp_context is not set yet")
             || message.contains("track is not binding yet")
+            || message.contains("DTLS transport has not started yet")
     }
 
     fn current_connection_state(

--- a/livetwo/src/protocol/rtp.rs
+++ b/livetwo/src/protocol/rtp.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Notify;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 use crate::utils;
 use rtsp::constants::media_type;
@@ -55,8 +55,6 @@ pub async fn setup_rtp_input(target_url: &str) -> Result<(rtsp::MediaInfo, Strin
             .map_err(|e| anyhow!("Invalid IP address in SDP: {}", e))?;
         host = addr.to_string();
     }
-    info!("SDP file parsed successfully");
-
     let video_track = sdp.medias.iter().find(|md| md.media == media_type::VIDEO);
     let audio_track = sdp.medias.iter().find(|md| md.media == media_type::AUDIO);
     let (codec_vid, codec_aud) = parse_codecs(&video_track, &audio_track);
@@ -93,6 +91,17 @@ pub async fn setup_rtp_input(target_url: &str) -> Result<(rtsp::MediaInfo, Strin
             None
         },
     };
+
+    warn!(
+        "SDP parsed: host={}, audio_port={:?}, video_port={:?}, audio_codec={}, video_codec={}, audio_transport={:?}, video_transport={:?}",
+        host,
+        audio_track.map(|t| t.port),
+        video_track.map(|t| t.port),
+        codec_aud,
+        codec_vid,
+        media_info.audio_transport,
+        media_info.video_transport,
+    );
 
     Ok((media_info, host))
 }

--- a/livetwo/src/whip/track.rs
+++ b/livetwo/src/whip/track.rs
@@ -418,10 +418,11 @@ pub async fn setup_audio_track(
         let mut first_write = true;
         let mut payload_type = initial_audio_payload_type;
         let mut payload_type_refreshed_at = Instant::now() - SENDER_PT_REFRESH_INTERVAL;
-        let mut handler: Box<dyn RePayload + Send> = match audio_codec.mime_type.as_str() {
-            MIME_TYPE_OPUS => Box::new(RePayloadCodec::new(audio_codec.mime_type.clone())),
-            _ => Box::new(Forward::new()),
-        };
+        // All audio codecs use Forward (passthrough). Audio RTP packets are
+        // self-contained frames and don't need depacketization/repacketization.
+        // Using RePayloadCodec would break codecs like OPUS whose marker-bit
+        // semantics (talkspurt boundary per RFC 7587) differ from video.
+        let mut handler: Box<dyn RePayload + Send> = Box::new(Forward::new());
 
         while let Some(data) = audio_rx.recv().await {
             if let Ok(packet) = Packet::unmarshal(&mut data.as_slice()) {


### PR DESCRIPTION
fix #342 

- rtsp: Use case-insensitive comparison for OPUS codec in SDP fmtp
- whep/liveion: Disable mDNS in SettingEngine (unnecessary for server-side WebRTC)
- subscribe: Treat 'DTLS transport has not started yet' as a transient error
- rtp: Improve SDP parse logging with detailed codec/transport info
- whip/track: Use Forward (passthrough) for all audio codecs instead of RePayloadCodec. Audio RTP packets are self-contained frames; using RePayloadCodec breaks OPUS marker-bit semantics (talkspurt boundary per RFC 7587) which differ from video.