### PR TITLE
fix(rtsp): support Basic auth and default port 554 in client

### DIFF
--- a/libs/rtsp/src/auth.rs
+++ b/libs/rtsp/src/auth.rs
@@ -64,6 +64,34 @@ pub fn generate_digest_response(
     format!("{:x}", Md5::digest(response.as_bytes()))
 }
 
+/// A parsed `WWW-Authenticate` challenge from a 401 response.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthChallenge {
+    /// HTTP Basic authentication (RFC 7617). The realm is not needed to
+    /// build the response, so it is not captured.
+    Basic,
+    /// HTTP Digest authentication (RFC 2069/2617).
+    Digest { realm: String, nonce: String },
+}
+
+/// Parse a `WWW-Authenticate` header, dispatching on the auth scheme.
+/// Basic-only devices (common on older IP cameras) send
+/// `Basic realm="..."`, which carries no nonce.
+pub fn parse_www_authenticate(header: &headers::HeaderValue) -> Result<AuthChallenge> {
+    let header_str = header.as_str();
+    let scheme_end = header_str
+        .find(char::is_whitespace)
+        .unwrap_or(header_str.len());
+    let scheme = &header_str[..scheme_end];
+
+    if scheme.eq_ignore_ascii_case("basic") {
+        return Ok(AuthChallenge::Basic);
+    }
+
+    let (realm, nonce) = parse_auth_header(header)?;
+    Ok(AuthChallenge::Digest { realm, nonce })
+}
+
 pub fn parse_auth_header(header: &headers::HeaderValue) -> Result<(String, String)> {
     let header_str = header.as_str();
 
@@ -211,5 +239,26 @@ mod tests {
         assert_eq!(nonce, "abc123");
         assert_eq!(uri, "/stream");
         assert_eq!(response, "deadbeef");
+    }
+
+    #[test]
+    fn test_parse_www_authenticate_basic() {
+        let header = headers::HeaderValue::from("Basic realm=\"WallyWorld\"");
+        assert_eq!(
+            parse_www_authenticate(&header).unwrap(),
+            AuthChallenge::Basic
+        );
+    }
+
+    #[test]
+    fn test_parse_www_authenticate_digest() {
+        let header = headers::HeaderValue::from("Digest realm=\"live777\", nonce=\"abc123\"");
+        assert_eq!(
+            parse_www_authenticate(&header).unwrap(),
+            AuthChallenge::Digest {
+                realm: "live777".to_string(),
+                nonce: "abc123".to_string()
+            }
+        );
     }
 }

--- a/libs/rtsp/src/client/session.rs
+++ b/libs/rtsp/src/client/session.rs
@@ -4,7 +4,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, trace};
 
 use super::RtspMode;
-use crate::auth::{AuthParams, generate_digest_response, parse_auth_header};
+use crate::auth::{AuthChallenge, AuthParams, generate_digest_response, parse_www_authenticate};
 use crate::channels::InterleavedChannel;
 use crate::constants::{buffer, client, media_type, net};
 use crate::transport_manager::{TransportConfig, UdpPortInfo};
@@ -118,13 +118,16 @@ where
         // Clone is necessary because rtsp_types::Request<Vec<u8>> does not
         // support body sharing.  ANNOUNCE SDP bodies are typically <10 KB
         // so the allocation is negligible.
-        let (realm, nonce) = parse_auth_header(auth_header)?;
-        let uri = original
-            .request_uri()
-            .map(|uri| uri.to_string())
-            .unwrap_or_else(|| self.url.clone());
-        let auth_header_value =
-            self.generate_authorization_header(&realm, &nonce, original.method(), &uri);
+        let auth_header_value = match parse_www_authenticate(auth_header)? {
+            AuthChallenge::Basic => self.auth_params.generate_basic_auth(),
+            AuthChallenge::Digest { realm, nonce } => {
+                let uri = original
+                    .request_uri()
+                    .map(|uri| uri.to_string())
+                    .unwrap_or_else(|| self.url.clone());
+                self.generate_authorization_header(&realm, &nonce, original.method(), &uri)
+            }
+        };
 
         let mut auth_request = original.clone();
         auth_request.insert_header(headers::CSEQ, self.cseq.to_string());
@@ -520,9 +523,9 @@ pub async fn setup_rtsp_session(
     let mut url = Url::parse(rtsp_url)?;
     info!("Connecting to RTSP server: {}", rtsp_url);
 
-    let port = url
-        .port_or_known_default()
-        .ok_or_else(|| anyhow!("No port specified"))?;
+    // `url::Url::port_or_known_default` only knows the "special" schemes
+    // (http/https/ws/wss/ftp); fall back to the RTSP default port 554.
+    let port = url.port_or_known_default().unwrap_or(554);
     let addr = format!("{}:{}", target_host, port);
 
     let stream = tokio::net::TcpStream::connect(&addr).await?;
@@ -823,5 +826,30 @@ mod tests {
         assert!(auth.contains("realm=\"live777\""));
         assert!(auth.contains("nonce=\"nonce-1\""));
         assert!(auth.contains("uri=\"rtsp://127.0.0.1:8554/live\""));
+    }
+
+    #[test]
+    fn authorized_retry_uses_basic_for_basic_challenge() {
+        let mut session = test_session();
+        session.cseq = 3;
+        let original = Request::builder(Method::Describe, Version::V1_0)
+            .request_uri("rtsp://127.0.0.1:8554/live".parse::<Url>().unwrap())
+            .header(headers::CSEQ, "2")
+            .header(headers::USER_AGENT, client::USER_AGENT)
+            .empty()
+            .map_body(|_| vec![]);
+        let challenge = headers::HeaderValue::from("Basic realm=\"WallyWorld\"");
+
+        let retry = session
+            .build_authorized_request(&original, &challenge)
+            .unwrap();
+
+        assert_eq!(retry.header(&headers::CSEQ).map(|h| h.as_str()), Some("3"));
+        let auth = retry
+            .header(&headers::AUTHORIZATION)
+            .map(|h| h.as_str())
+            .unwrap();
+        // base64("user:pass")
+        assert_eq!(auth, "Basic dXNlcjpwYXNz");
     }
 }


### PR DESCRIPTION
## Summary
- The RTSP client only implemented Digest authentication. Basic-only devices (older IP cameras sending `WWW-Authenticate: Basic realm="..."`) failed at DESCRIBE with "Missing 'realm' in WWW-Authenticate header" after logging `Ignoring parameter: Basic realm=...`. The client now dispatches on the challenge scheme and answers Basic challenges with the existing `generate_basic_auth()`; Digest behavior is unchanged.
- Fall back to the RTSP default port 554 when the URL has no explicit port, since `url::Url::port_or_known_default` does not know the `rtsp` scheme (`rtsp://user:pass@host/stream` previously errored with "No port specified").

Fixes #355

## Test plan
- [x] `cargo test -p rtsp` — 46 passed, including new tests: `test_parse_www_authenticate_basic`, `test_parse_www_authenticate_digest`, `authorized_retry_uses_basic_for_basic_challenge`
- [x] `cargo clippy -p rtsp --all-targets -- -D warnings`
- [x] `cargo fmt -p rtsp -- --check`
- [x] `cargo check -p livetwo --all-targets` and `cargo check --bin whipinto --bin whepfrom`
- [ ] Verified against a real Basic-only camera (not available locally; the 401-retry path covers DESCRIBE/ANNOUNCE, same as the existing Digest flow)