### PR TITLE
refactor(livetwo): unify WHIP publish core and add synth input

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,9 @@ Built from `src/bin/` or `src/<name>.rs` in the root crate:
 - `liveman`      — cluster manager for multiple `live777` nodes.
 - `livecam`      — camera ingest server.
 - `livetwo`      — provided as a library; command tools below use it.
-- `whipinto`     — push RTP/RTSP into a WHIP endpoint.
+- `whipinto`     — push RTP/RTSP into a WHIP endpoint; with the `rsmpeg`
+  feature it also accepts a `synth://<vcodec>?...` input that publishes
+  in-process generated test frames (no external encoder needed).
 - `whepfrom`     — pull a WHEP stream and output RTP/RTSP.
 - `whepwright`   — browser-based WHEP playback tester (feature gated).
 - `livevod`      — VOD/recording playback helper.
@@ -172,7 +174,9 @@ and linker paths.
   manages cascade state, records via cluster policy, and stores recording
   indexes in a database.
 - `livetwo` is the protocol-conversion engine used by `whipinto`/`whepfrom`
-  and the `cascade` feature.
+  and the `cascade` feature. `livetwo/src/whip/core.rs` is the single WHIP
+  publish core (peer construction, connection waits, ICE diagnostics) shared
+  by the RTP/RTSP bridge and the synthetic `whipsynth` publisher.
 - `livecam` is a focused camera ingest server with its own config and WebUI.
 - `net4mqtt` exposes a local SOCKS proxy and tunnels traffic over MQTT for
   NAT/remote agents.

--- a/livetwo/src/lib.rs
+++ b/livetwo/src/lib.rs
@@ -16,3 +16,4 @@ pub const PREFIX_LIB: &str = "WEBRTC";
 pub const SCHEME_RTSP_SERVER: &str = "rtsp-listen";
 pub const SCHEME_RTSP_CLIENT: &str = "rtsp";
 pub const SCHEME_RTP_SDP: &str = "sdp";
+pub const SCHEME_SYNTH: &str = "synth";

--- a/livetwo/src/whip/core.rs
+++ b/livetwo/src/whip/core.rs
@@ -1,0 +1,495 @@
+//! Unified WHIP publish core shared by the RTP/RTSP bridge ([`crate::whip::into`])
+//! and the synthetic publisher ([`crate::whipsynth::Publisher`]).
+//!
+//! The core owns peer construction (media engine, interceptors, ICE config,
+//! event handler), connection-state waits and failure diagnostics. Callers add
+//! their own tracks and media pumps on top of [`PublishPeer`].
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::{Result, anyhow};
+use rtc::peer_connection::configuration::interceptor_registry::{
+    configure_nack, configure_rtcp_reports, configure_simulcast_extension_headers, configure_twcc,
+};
+use rtc::rtp_transceiver::rtp_sender::{RTCRtpCodecParameters, RtpCodecKind};
+use rtc::statistics::StatsSelector;
+use rtc::statistics::report::RTCStatsReportEntry;
+use tokio::sync::{Notify, watch};
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+use webrtc::peer_connection::{
+    MediaEngine, PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler,
+    RTCConfigurationBuilder, RTCIceConnectionState, RTCIceGatheringState, RTCIceServer,
+    RTCPeerConnectionState, RTCSignalingState, Registry,
+};
+
+use crate::utils;
+
+/// Default STUN server used when the caller does not override ICE servers.
+pub const DEFAULT_STUN_SERVER: &str = "stun:stun.l.google.com:19302";
+
+/// How long to wait for the peer to reach `Connected` before giving up.
+const WAIT_FOR_PEER_CONNECTED_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Options for [`create_publish_peer`].
+pub struct PublishPeerOptions {
+    /// STUN server URL used for ICE gathering. `None` (or blank) disables ICE
+    /// servers, which is useful on loopback-only test setups.
+    pub stun_server: Option<String>,
+    /// Extra video codec registrations applied *before* the default codecs so
+    /// the SDP offer prefers them (e.g. H265 with sprop parameters or AV1 with
+    /// a resolution-derived level-idx).
+    pub extra_video_codecs: Vec<RTCRtpCodecParameters>,
+    /// When true the event handler cancels the session token as soon as the
+    /// peer fails or closes. Used by the synthetic publisher; the RTP/RTSP
+    /// bridge reports failures via [`wait_for_unexpected_peer_end`] instead.
+    pub cancel_on_failure: bool,
+}
+
+impl Default for PublishPeerOptions {
+    fn default() -> Self {
+        Self {
+            stun_server: Some(DEFAULT_STUN_SERVER.to_string()),
+            extra_video_codecs: Vec::new(),
+            cancel_on_failure: false,
+        }
+    }
+}
+
+/// A peer built by [`create_publish_peer`]. Tracks are added by the caller.
+pub struct PublishPeer {
+    pub peer: Arc<dyn PeerConnection>,
+    pub state_rx: watch::Receiver<RTCPeerConnectionState>,
+    pub diagnostics: Arc<PublishDiagnostics>,
+}
+
+/// Create a WHIP publish peer: media engine with the default codecs (plus any
+/// extra registrations), NACK/RTCP reports/TWCC interceptors, event handler
+/// and ICE configuration.
+pub async fn create_publish_peer(
+    ct: CancellationToken,
+    gather_complete: Arc<Notify>,
+    options: PublishPeerOptions,
+) -> Result<PublishPeer> {
+    let mut m = MediaEngine::default();
+    for codec in options.extra_video_codecs {
+        m.register_codec(codec, RtpCodecKind::Video)?;
+    }
+    m.register_default_codecs()?;
+
+    let registry = Registry::new();
+    let registry = configure_nack(registry, &mut m);
+    let registry = configure_rtcp_reports(registry);
+    configure_simulcast_extension_headers(&mut m)?;
+    let registry = configure_twcc(registry, &mut m)?;
+    info!("WHIP publish peer configured with NACK, RTCP reports, and TWCC");
+
+    let (state_tx, state_rx) = watch::channel(RTCPeerConnectionState::New);
+    let diagnostics = Arc::new(PublishDiagnostics::default());
+    let handler: Arc<dyn PeerConnectionEventHandler> = Arc::new(PublishPeerHandler {
+        ct,
+        gather_complete,
+        state_tx,
+        diagnostics: diagnostics.clone(),
+        cancel_on_failure: options.cancel_on_failure,
+    });
+
+    let mut config_builder = RTCConfigurationBuilder::new();
+    if let Some(stun_server) = options.stun_server.filter(|s| !s.trim().is_empty()) {
+        config_builder = config_builder.with_ice_servers(vec![RTCIceServer {
+            urls: vec![stun_server],
+            username: String::new(),
+            credential: String::new(),
+        }]);
+    }
+
+    let peer: Arc<dyn PeerConnection> = Arc::new(
+        PeerConnectionBuilder::new()
+            .with_media_engine(m)
+            .with_interceptor_registry(registry)
+            .with_handler(handler)
+            .with_udp_addrs(utils::webrtc::ice_udp_addrs())
+            .with_configuration(config_builder.build())
+            .build()
+            .await
+            .map_err(|error| anyhow!(format!("{:?}: {}", error, error)))?,
+    );
+
+    Ok(PublishPeer {
+        peer,
+        state_rx,
+        diagnostics,
+    })
+}
+
+/// Wait until the peer reaches `Connected`, with diagnostics on failure.
+pub async fn wait_for_peer_connected(
+    peer: Arc<dyn PeerConnection>,
+    state_rx: watch::Receiver<RTCPeerConnectionState>,
+    diagnostics: Arc<PublishDiagnostics>,
+) -> Result<()> {
+    wait_for_peer_connected_with_timeout(
+        state_rx,
+        diagnostics,
+        WAIT_FOR_PEER_CONNECTED_TIMEOUT,
+        move || {
+            let peer = peer.clone();
+            async move { format_ice_stats(peer).await }
+        },
+    )
+    .await
+}
+
+pub async fn wait_for_peer_connected_with_timeout<F, Fut>(
+    mut state_rx: watch::Receiver<RTCPeerConnectionState>,
+    diagnostics: Arc<PublishDiagnostics>,
+    timeout: Duration,
+    ice_stats: F,
+) -> Result<()>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = String>,
+{
+    let wait_result = tokio::time::timeout(timeout, async {
+        loop {
+            let state = *state_rx.borrow_and_update();
+            match state {
+                RTCPeerConnectionState::Connected => return Ok(()),
+                RTCPeerConnectionState::Failed
+                | RTCPeerConnectionState::Closed
+                | RTCPeerConnectionState::Disconnected => {
+                    return Err(anyhow!(
+                        "WHIP peer connection ended before becoming connected: state={state}"
+                    ));
+                }
+                _ => {}
+            }
+
+            state_rx
+                .changed()
+                .await
+                .map_err(|_| anyhow!("WHIP peer connection state channel closed"))?;
+        }
+    })
+    .await;
+
+    match wait_result {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(error)) => {
+            let ice_stats = ice_stats().await;
+            Err(anyhow!(
+                "{error}, {}, ice_stats=[{}]",
+                diagnostics.format(),
+                ice_stats
+            ))
+        }
+        Err(_) => {
+            let ice_stats = ice_stats().await;
+            Err(anyhow!(
+                "WHIP peer connection timed out waiting for connected after {:?}: {}, ice_stats=[{}]",
+                timeout,
+                diagnostics.format(),
+                ice_stats
+            ))
+        }
+    }
+}
+
+/// Watch a connected peer and return an error if it ends before shutdown.
+pub async fn wait_for_unexpected_peer_end(
+    peer: Arc<dyn PeerConnection>,
+    mut state_rx: watch::Receiver<RTCPeerConnectionState>,
+    diagnostics: Arc<PublishDiagnostics>,
+) -> Result<()> {
+    let mut saw_connected = *state_rx.borrow() == RTCPeerConnectionState::Connected;
+
+    loop {
+        let state = *state_rx.borrow();
+        if state == RTCPeerConnectionState::Connected {
+            saw_connected = true;
+        }
+
+        if matches!(
+            state,
+            RTCPeerConnectionState::Failed
+                | RTCPeerConnectionState::Closed
+                | RTCPeerConnectionState::Disconnected
+        ) {
+            let ice_stats = format_ice_stats(peer.clone()).await;
+            return Err(anyhow!(
+                "WHIP peer connection ended before shutdown: state={state}, connected_before={saw_connected}, {}, ice_stats=[{}]",
+                diagnostics.format(),
+                ice_stats
+            ));
+        }
+
+        state_rx
+            .changed()
+            .await
+            .map_err(|_| anyhow!("WHIP peer connection state channel closed"))?;
+    }
+}
+
+/// Connection diagnostics captured during a publish session for error reports.
+#[derive(Default)]
+pub struct PublishDiagnostics {
+    connection_states: Mutex<Vec<String>>,
+    ice_connection_states: Mutex<Vec<String>>,
+    ice_gathering_states: Mutex<Vec<String>>,
+    signaling_states: Mutex<Vec<String>>,
+    local_sdp_summary: Mutex<Option<String>>,
+    remote_sdp_summary: Mutex<Option<String>>,
+}
+
+impl PublishDiagnostics {
+    pub fn set_sdp_summaries(&self, local: String, remote: String) {
+        if let Ok(mut summary) = self.local_sdp_summary.lock() {
+            *summary = Some(local);
+        }
+        if let Ok(mut summary) = self.remote_sdp_summary.lock() {
+            *summary = Some(remote);
+        }
+    }
+
+    pub fn format(&self) -> String {
+        format!(
+            "connection_states=[{}], ice_connection_states=[{}], ice_gathering_states=[{}], signaling_states=[{}], local_sdp_summary=[{}], remote_sdp_summary=[{}]",
+            join_states(&self.connection_states),
+            join_states(&self.ice_connection_states),
+            join_states(&self.ice_gathering_states),
+            join_states(&self.signaling_states),
+            optional_summary(&self.local_sdp_summary),
+            optional_summary(&self.remote_sdp_summary),
+        )
+    }
+}
+
+fn push_state(states: &Mutex<Vec<String>>, state: impl std::fmt::Display) {
+    match states.lock() {
+        Ok(mut states) => states.push(state.to_string()),
+        Err(poisoned) => {
+            // Recover the inner data after a panic so diagnostics are still
+            // available for error reporting.
+            let mut states = poisoned.into_inner();
+            states.push(state.to_string());
+        }
+    }
+}
+
+fn join_states(states: &Mutex<Vec<String>>) -> String {
+    states
+        .lock()
+        .map(|states| states.join(" -> "))
+        .unwrap_or_else(|poisoned| format!("{}(poisoned)", poisoned.into_inner().join(" -> ")))
+}
+
+fn optional_summary(summary: &Mutex<Option<String>>) -> String {
+    summary
+        .lock()
+        .map(|summary| {
+            summary
+                .as_deref()
+                .unwrap_or("<not captured>")
+                .replace('\n', " | ")
+        })
+        .unwrap_or_else(|_| "<poisoned>".to_string())
+}
+
+struct PublishPeerHandler {
+    ct: CancellationToken,
+    gather_complete: Arc<Notify>,
+    state_tx: watch::Sender<RTCPeerConnectionState>,
+    diagnostics: Arc<PublishDiagnostics>,
+    cancel_on_failure: bool,
+}
+
+#[async_trait::async_trait]
+impl PeerConnectionEventHandler for PublishPeerHandler {
+    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
+        info!("WHIP publish connection state changed: {}", state);
+        push_state(&self.diagnostics.connection_states, state);
+        let _ = self.state_tx.send(state);
+        if self.cancel_on_failure
+            && matches!(
+                state,
+                RTCPeerConnectionState::Failed | RTCPeerConnectionState::Closed
+            )
+        {
+            self.ct.cancel();
+        }
+    }
+
+    async fn on_ice_connection_state_change(&self, state: RTCIceConnectionState) {
+        info!("WHIP publish ICE connection state changed: {}", state);
+        push_state(&self.diagnostics.ice_connection_states, state);
+    }
+
+    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
+        info!("WHIP publish ICE gathering state changed: {}", state);
+        push_state(&self.diagnostics.ice_gathering_states, state);
+        if state == RTCIceGatheringState::Complete {
+            info!("WHIP publish ICE gathering complete");
+            self.gather_complete.notify_one();
+        }
+    }
+
+    async fn on_signaling_state_change(&self, state: RTCSignalingState) {
+        info!("WHIP publish signaling state changed: {}", state);
+        push_state(&self.diagnostics.signaling_states, state);
+    }
+}
+
+pub async fn format_ice_stats(peer: Arc<dyn PeerConnection>) -> String {
+    let report = peer
+        .get_stats(std::time::Instant::now(), StatsSelector::None)
+        .await;
+    let mut lines = Vec::new();
+
+    for entry in report.iter() {
+        match entry {
+            RTCStatsReportEntry::IceCandidatePair(pair) => {
+                lines.push(format!(
+                    "candidate_pair id={} local={} remote={} state={:?} nominated={} packets_sent={} packets_received={} bytes_sent={} bytes_received={} requests_sent={} requests_received={} responses_sent={} responses_received={}",
+                    pair.stats.id,
+                    pair.local_candidate_id,
+                    pair.remote_candidate_id,
+                    pair.state,
+                    pair.nominated,
+                    pair.packets_sent,
+                    pair.packets_received,
+                    pair.bytes_sent,
+                    pair.bytes_received,
+                    pair.requests_sent,
+                    pair.requests_received,
+                    pair.responses_sent,
+                    pair.responses_received,
+                ));
+            }
+            RTCStatsReportEntry::LocalCandidate(candidate) => {
+                lines.push(format!(
+                    "local_candidate id={} address={} port={} protocol={} type={:?} foundation={} related={}:{}",
+                    candidate.stats.id,
+                    candidate.address.as_deref().unwrap_or("<redacted>"),
+                    candidate.port,
+                    candidate.protocol,
+                    candidate.candidate_type,
+                    candidate.foundation,
+                    candidate.related_address,
+                    candidate.related_port,
+                ));
+            }
+            RTCStatsReportEntry::RemoteCandidate(candidate) => {
+                lines.push(format!(
+                    "remote_candidate id={} address={} port={} protocol={} type={:?} foundation={} related={}:{}",
+                    candidate.stats.id,
+                    candidate.address.as_deref().unwrap_or("<redacted>"),
+                    candidate.port,
+                    candidate.protocol,
+                    candidate.candidate_type,
+                    candidate.foundation,
+                    candidate.related_address,
+                    candidate.related_port,
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    if lines.is_empty() {
+        "<no ice candidate stats>".to_string()
+    } else {
+        lines.join("; ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[tokio::test]
+    async fn waits_for_connected_before_starting_media_transport() {
+        let (state_tx, state_rx) = watch::channel(RTCPeerConnectionState::New);
+        let diagnostics = Arc::new(PublishDiagnostics::default());
+        let started = Arc::new(AtomicUsize::new(0));
+        let order = Arc::new(Mutex::new(Vec::new()));
+
+        let task = {
+            let started = started.clone();
+            let order = order.clone();
+            tokio::spawn(async move {
+                wait_for_peer_connected_with_timeout(
+                    state_rx.clone(),
+                    diagnostics,
+                    Duration::from_secs(1),
+                    || async { "ice-stats".to_string() },
+                )
+                .await?;
+
+                started.fetch_add(1, Ordering::SeqCst);
+                order.lock().unwrap().push("stats");
+                started.fetch_add(1, Ordering::SeqCst);
+                order.lock().unwrap().push("transport");
+                Result::<()>::Ok(())
+            })
+        };
+
+        tokio::time::sleep(Duration::from_millis(25)).await;
+        assert_eq!(started.load(Ordering::SeqCst), 0);
+
+        state_tx.send(RTCPeerConnectionState::Connected).unwrap();
+
+        task.await.unwrap().unwrap();
+        assert_eq!(started.load(Ordering::SeqCst), 2);
+        assert_eq!(order.lock().unwrap().as_slice(), ["stats", "transport"]);
+    }
+
+    #[tokio::test]
+    async fn returns_error_with_diagnostics_when_peer_fails_before_connected() {
+        for state in [
+            RTCPeerConnectionState::Failed,
+            RTCPeerConnectionState::Closed,
+            RTCPeerConnectionState::Disconnected,
+        ] {
+            let (state_tx, state_rx) = watch::channel(RTCPeerConnectionState::New);
+            let diagnostics = Arc::new(PublishDiagnostics::default());
+
+            state_tx.send(state).unwrap();
+
+            let error = wait_for_peer_connected_with_timeout(
+                state_rx,
+                diagnostics,
+                Duration::from_secs(1),
+                || async { "candidate_pair state=failed".to_string() },
+            )
+            .await
+            .unwrap_err()
+            .to_string();
+
+            assert!(error.contains("before becoming connected"));
+            assert!(error.contains("connection_states="));
+            assert!(error.contains("candidate_pair state=failed"));
+        }
+    }
+
+    #[tokio::test]
+    async fn returns_error_with_diagnostics_when_wait_for_connected_times_out() {
+        let (_state_tx, state_rx) = watch::channel(RTCPeerConnectionState::New);
+        let diagnostics = Arc::new(PublishDiagnostics::default());
+
+        let error = wait_for_peer_connected_with_timeout(
+            state_rx,
+            diagnostics,
+            Duration::from_millis(10),
+            || async { "<no ice candidate stats>".to_string() },
+        )
+        .await
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("timed out waiting"));
+        assert!(error.contains("connection_states="));
+        assert!(error.contains("<no ice candidate stats>"));
+    }
+}

--- a/livetwo/src/whip/mod.rs
+++ b/livetwo/src/whip/mod.rs
@@ -1,13 +1,12 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use ::webrtc::peer_connection::RTCPeerConnectionState;
 use anyhow::{Result, anyhow};
 use std::process::ExitStatus;
-use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
+pub mod core;
 mod input;
 mod track;
 mod webrtc;
@@ -18,12 +17,10 @@ use crate::utils::stats::start_stats_monitor;
 use cli::create_child;
 use libwish::Client;
 
+pub use core::format_ice_stats;
 pub use input::InputSource;
-pub use webrtc::format_ice_stats;
 pub(crate) use webrtc::log_rtcp_feedback_packet;
 pub use webrtc::setup_whip_peer;
-
-const WAIT_FOR_PEER_CONNECTED_TIMEOUT: Duration = Duration::from_secs(15);
 
 pub async fn into(
     ct: CancellationToken,
@@ -33,6 +30,26 @@ pub async fn into(
     command: Option<String>,
 ) -> Result<()> {
     info!("Starting WHIP session: {}", target_url);
+
+    // Synthetic input: generate frames in-process and publish them directly,
+    // bypassing the RTP/RTSP input bridge entirely.
+    #[cfg(feature = "rsmpeg")]
+    if let Some(publisher) =
+        crate::whipsynth::publisher_from_input(&target_url, whip_url.clone(), token.clone())?
+    {
+        if command.is_some() {
+            anyhow::bail!("--command is not supported with a synthetic input");
+        }
+        let stats = publisher.run(ct).await?;
+        info!(
+            packets_sent = stats.packets_sent,
+            bytes_sent = stats.bytes_sent,
+            nack_count = stats.nack_count,
+            pli_count = stats.pli_count,
+            "Synthetic WHIP session ended"
+        );
+        return Ok(());
+    }
 
     let mut client = Client::new(whip_url.clone(), Client::get_auth_header_map(token.clone()));
 
@@ -51,7 +68,7 @@ pub async fn into(
         .await?;
     info!("WHIP peer setup completed; waiting for WebRTC connection");
 
-    wait_for_peer_connected(
+    core::wait_for_peer_connected(
         peer.clone(),
         peer_state_rx.clone(),
         peer_diagnostics.clone(),
@@ -98,7 +115,7 @@ pub async fn into(
                 graceful_shutdown("WHIP", &mut client, peer).await;
                 Ok(())
             }
-            result = wait_for_unexpected_peer_end(peer.clone(), peer_state_rx, peer_diagnostics) => {
+            result = core::wait_for_unexpected_peer_end(peer.clone(), peer_state_rx, peer_diagnostics) => {
                 ct.cancel();
                 graceful_shutdown("WHIP", &mut client, peer).await;
                 result
@@ -117,117 +134,11 @@ pub async fn into(
                 graceful_shutdown("WHIP", &mut client, peer).await;
                 Ok(())
             }
-            result = wait_for_unexpected_peer_end(peer.clone(), peer_state_rx, peer_diagnostics) => {
+            result = core::wait_for_unexpected_peer_end(peer.clone(), peer_state_rx, peer_diagnostics) => {
                 ct.cancel();
                 graceful_shutdown("WHIP", &mut client, peer).await;
                 result
             }
-        }
-    }
-}
-
-async fn wait_for_peer_connected(
-    peer: Arc<dyn ::webrtc::peer_connection::PeerConnection>,
-    state_rx: watch::Receiver<RTCPeerConnectionState>,
-    diagnostics: Arc<webrtc::WhipPeerDiagnostics>,
-) -> Result<()> {
-    wait_for_peer_connected_with_timeout(
-        state_rx,
-        diagnostics,
-        WAIT_FOR_PEER_CONNECTED_TIMEOUT,
-        move || {
-            let peer = peer.clone();
-            async move { webrtc::format_ice_stats(peer).await }
-        },
-    )
-    .await
-}
-
-async fn wait_for_peer_connected_with_timeout<F, Fut>(
-    mut state_rx: watch::Receiver<RTCPeerConnectionState>,
-    diagnostics: Arc<webrtc::WhipPeerDiagnostics>,
-    timeout: Duration,
-    ice_stats: F,
-) -> Result<()>
-where
-    F: Fn() -> Fut,
-    Fut: std::future::Future<Output = String>,
-{
-    let wait_result = tokio::time::timeout(timeout, async {
-        loop {
-            let state = *state_rx.borrow_and_update();
-            match state {
-                RTCPeerConnectionState::Connected => return Ok(()),
-                RTCPeerConnectionState::Failed
-                | RTCPeerConnectionState::Closed
-                | RTCPeerConnectionState::Disconnected => {
-                    return Err(anyhow!(
-                        "WHIP peer connection ended before becoming connected: state={state}"
-                    ));
-                }
-                _ => {}
-            }
-
-            state_rx
-                .changed()
-                .await
-                .map_err(|_| anyhow!("WHIP peer connection state channel closed"))?;
-        }
-    })
-    .await;
-
-    match wait_result {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(error)) => {
-            let ice_stats = ice_stats().await;
-            Err(anyhow!(
-                "{error}, {}, ice_stats=[{}]",
-                diagnostics.format(),
-                ice_stats
-            ))
-        }
-        Err(_) => {
-            let ice_stats = ice_stats().await;
-            Err(anyhow!(
-                "WHIP peer connection timed out waiting for connected after {:?}: {}, ice_stats=[{}]",
-                timeout,
-                diagnostics.format(),
-                ice_stats
-            ))
-        }
-    }
-}
-
-async fn wait_for_unexpected_peer_end(
-    peer: Arc<dyn ::webrtc::peer_connection::PeerConnection>,
-    mut state_rx: watch::Receiver<RTCPeerConnectionState>,
-    diagnostics: Arc<webrtc::WhipPeerDiagnostics>,
-) -> Result<()> {
-    let mut saw_connected = *state_rx.borrow() == RTCPeerConnectionState::Connected;
-
-    loop {
-        state_rx
-            .changed()
-            .await
-            .map_err(|_| anyhow!("WHIP peer connection state channel closed"))?;
-
-        let state = *state_rx.borrow();
-        if state == RTCPeerConnectionState::Connected {
-            saw_connected = true;
-        }
-
-        if matches!(
-            state,
-            RTCPeerConnectionState::Failed
-                | RTCPeerConnectionState::Closed
-                | RTCPeerConnectionState::Disconnected
-        ) {
-            let ice_stats = webrtc::format_ice_stats(peer.clone()).await;
-            return Err(anyhow!(
-                "WHIP peer connection ended before shutdown: state={state}, connected_before={saw_connected}, {}, ice_stats=[{}]",
-                diagnostics.format(),
-                ice_stats
-            ));
         }
     }
 }
@@ -245,99 +156,5 @@ async fn wait_for_child_exit(child: Arc<Option<cli::ChildGuard>>) -> Result<Exit
                 return Ok(status);
             }
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::sync::{
-        Arc, Mutex,
-        atomic::{AtomicUsize, Ordering},
-    };
-
-    #[tokio::test]
-    async fn waits_for_connected_before_starting_media_transport() {
-        let (state_tx, state_rx) = watch::channel(RTCPeerConnectionState::New);
-        let diagnostics = Arc::new(webrtc::WhipPeerDiagnostics::default());
-        let started = Arc::new(AtomicUsize::new(0));
-        let order = Arc::new(Mutex::new(Vec::new()));
-
-        let task = {
-            let started = started.clone();
-            let order = order.clone();
-            tokio::spawn(async move {
-                wait_for_peer_connected_with_timeout(
-                    state_rx.clone(),
-                    diagnostics,
-                    Duration::from_secs(1),
-                    || async { "ice-stats".to_string() },
-                )
-                .await?;
-
-                started.fetch_add(1, Ordering::SeqCst);
-                order.lock().unwrap().push("stats");
-                started.fetch_add(1, Ordering::SeqCst);
-                order.lock().unwrap().push("transport");
-                Result::<()>::Ok(())
-            })
-        };
-
-        tokio::time::sleep(Duration::from_millis(25)).await;
-        assert_eq!(started.load(Ordering::SeqCst), 0);
-
-        state_tx.send(RTCPeerConnectionState::Connected).unwrap();
-
-        task.await.unwrap().unwrap();
-        assert_eq!(started.load(Ordering::SeqCst), 2);
-        assert_eq!(order.lock().unwrap().as_slice(), ["stats", "transport"]);
-    }
-
-    #[tokio::test]
-    async fn returns_error_with_diagnostics_when_peer_fails_before_connected() {
-        for state in [
-            RTCPeerConnectionState::Failed,
-            RTCPeerConnectionState::Closed,
-            RTCPeerConnectionState::Disconnected,
-        ] {
-            let (state_tx, state_rx) = watch::channel(RTCPeerConnectionState::New);
-            let diagnostics = Arc::new(webrtc::WhipPeerDiagnostics::default());
-
-            state_tx.send(state).unwrap();
-
-            let error = wait_for_peer_connected_with_timeout(
-                state_rx,
-                diagnostics,
-                Duration::from_secs(1),
-                || async { "candidate_pair state=failed".to_string() },
-            )
-            .await
-            .unwrap_err()
-            .to_string();
-
-            assert!(error.contains("before becoming connected"));
-            assert!(error.contains("connection_states="));
-            assert!(error.contains("candidate_pair state=failed"));
-        }
-    }
-
-    #[tokio::test]
-    async fn returns_error_with_diagnostics_when_wait_for_connected_times_out() {
-        let (_state_tx, state_rx) = watch::channel(RTCPeerConnectionState::New);
-        let diagnostics = Arc::new(webrtc::WhipPeerDiagnostics::default());
-
-        let error = wait_for_peer_connected_with_timeout(
-            state_rx,
-            diagnostics,
-            Duration::from_millis(10),
-            || async { "<no ice candidate stats>".to_string() },
-        )
-        .await
-        .unwrap_err()
-        .to_string();
-
-        assert!(error.contains("timed out waiting"));
-        assert!(error.contains("connection_states="));
-        assert!(error.contains("<no ice candidate stats>"));
     }
 }

--- a/livetwo/src/whip/webrtc.rs
+++ b/livetwo/src/whip/webrtc.rs
@@ -1,12 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
-use anyhow::{Result, anyhow};
+use anyhow::Result;
 use libwish::Client;
-use rtc::peer_connection::configuration::interceptor_registry::{
-    configure_nack, configure_rtcp_reports, configure_simulcast_extension_headers, configure_twcc,
-};
-use rtc::statistics::StatsSelector;
-use rtc::statistics::report::RTCStatsReportEntry;
 use rtc_rtcp::payload_feedbacks::full_intra_request::FullIntraRequest;
 use rtc_rtcp::payload_feedbacks::picture_loss_indication::PictureLossIndication;
 use rtc_rtcp::payload_feedbacks::receiver_estimated_maximum_bitrate::ReceiverEstimatedMaximumBitrate;
@@ -15,15 +10,12 @@ use rtc_rtcp::transport_feedbacks::transport_layer_cc::TransportLayerCc;
 use rtc_rtcp::transport_feedbacks::transport_layer_nack::TransportLayerNack;
 use tokio::sync::{Notify, mpsc::UnboundedSender, watch};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, info};
-use webrtc::peer_connection::{
-    MediaEngine, PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler,
-    RTCConfigurationBuilder, RTCIceConnectionState, RTCIceGatheringState, RTCIceServer,
-    RTCPeerConnectionState, RTCSignalingState, Registry,
-};
+use tracing::debug;
+use webrtc::peer_connection::{PeerConnection, RTCPeerConnectionState};
 
 use crate::utils;
 use crate::utils::stats::RtcpStats;
+use crate::whip::core::{self, PublishDiagnostics, PublishPeerOptions};
 use crate::whip::track;
 
 pub async fn setup_whip_peer(
@@ -37,86 +29,17 @@ pub async fn setup_whip_peer(
     Option<UnboundedSender<Vec<u8>>>,
     Arc<RtcpStats>,
     watch::Receiver<RTCPeerConnectionState>,
-    Arc<WhipPeerDiagnostics>,
+    Arc<PublishDiagnostics>,
 )> {
     let gather_complete = Arc::new(Notify::new());
-    let (peer, video_sender, audio_sender, state_rx, diagnostics) =
-        create_peer(ct.clone(), media_info, input_id, gather_complete.clone()).await?;
 
-    utils::webrtc::setup_connection(peer.clone(), client, gather_complete).await?;
-    diagnostics.set_sdp_summaries(
-        peer.local_description()
-            .await
-            .map(|description| utils::webrtc::summarize_sdp(&description.sdp))
-            .unwrap_or_else(|| "<no local description>".to_string()),
-        peer.remote_description()
-            .await
-            .map(|description| utils::webrtc::summarize_sdp(&description.sdp))
-            .unwrap_or_else(|| "<no remote description>".to_string()),
-    );
-
-    let stats = Arc::new(RtcpStats::new());
-
-    Ok((
-        peer,
-        video_sender,
-        audio_sender,
-        stats,
-        state_rx,
-        diagnostics,
-    ))
-}
-
-async fn create_peer(
-    ct: CancellationToken,
-    media_info: &rtsp::MediaInfo,
-    input_id: String,
-    gather_complete: Arc<Notify>,
-) -> Result<(
-    Arc<dyn PeerConnection>,
-    Option<UnboundedSender<Vec<u8>>>,
-    Option<UnboundedSender<Vec<u8>>>,
-    watch::Receiver<RTCPeerConnectionState>,
-    Arc<WhipPeerDiagnostics>,
-)> {
-    let mut m = MediaEngine::default();
-    m.register_default_codecs()?;
-
-    let registry = Registry::new();
-    let registry = configure_nack(registry, &mut m);
-    let registry = configure_rtcp_reports(registry);
-    configure_simulcast_extension_headers(&mut m)?;
-    let registry = configure_twcc(registry, &mut m)?;
-    info!("WHIP peer configured with NACK, RTCP reports, and full TWCC");
-
-    let (state_tx, state_rx) = watch::channel(RTCPeerConnectionState::New);
-    let diagnostics = Arc::new(WhipPeerDiagnostics::default());
-    let handler: Arc<dyn PeerConnectionEventHandler> = Arc::new(WhipPeerHandler {
-        _ct: ct,
-        gather_complete,
-        state_tx,
-        diagnostics: diagnostics.clone(),
-    });
-
-    let config = RTCConfigurationBuilder::new()
-        .with_ice_servers(vec![RTCIceServer {
-            urls: vec!["stun:stun.l.google.com:19302".to_string()],
-            username: "".to_string(),
-            credential: "".to_string(),
-        }])
-        .build();
-
-    let peer: Arc<dyn PeerConnection> = Arc::new(
-        PeerConnectionBuilder::new()
-            .with_media_engine(m)
-            .with_interceptor_registry(registry)
-            .with_handler(handler)
-            .with_udp_addrs(utils::webrtc::ice_udp_addrs())
-            .with_configuration(config)
-            .build()
-            .await
-            .map_err(|error| anyhow!(format!("{:?}: {}", error, error)))?,
-    );
+    let publish = core::create_publish_peer(
+        ct.clone(),
+        gather_complete.clone(),
+        PublishPeerOptions::default(),
+    )
+    .await?;
+    let peer = publish.peer;
 
     let video_tx = if let Some(ref video_codec_params) = media_info.video_codec {
         track::setup_video_track(peer.clone(), video_codec_params, input_id.clone()).await?
@@ -138,100 +61,28 @@ async fn create_peer(
         None
     };
 
-    Ok((peer, video_tx, audio_tx, state_rx, diagnostics))
-}
+    utils::webrtc::setup_connection(peer.clone(), client, gather_complete).await?;
+    publish.diagnostics.set_sdp_summaries(
+        peer.local_description()
+            .await
+            .map(|description| utils::webrtc::summarize_sdp(&description.sdp))
+            .unwrap_or_else(|| "<no local description>".to_string()),
+        peer.remote_description()
+            .await
+            .map(|description| utils::webrtc::summarize_sdp(&description.sdp))
+            .unwrap_or_else(|| "<no remote description>".to_string()),
+    );
 
-struct WhipPeerHandler {
-    _ct: CancellationToken,
-    gather_complete: Arc<Notify>,
-    state_tx: watch::Sender<RTCPeerConnectionState>,
-    diagnostics: Arc<WhipPeerDiagnostics>,
-}
+    let stats = Arc::new(RtcpStats::new());
 
-#[derive(Default)]
-pub struct WhipPeerDiagnostics {
-    connection_states: Mutex<Vec<String>>,
-    ice_connection_states: Mutex<Vec<String>>,
-    ice_gathering_states: Mutex<Vec<String>>,
-    signaling_states: Mutex<Vec<String>>,
-    local_sdp_summary: Mutex<Option<String>>,
-    remote_sdp_summary: Mutex<Option<String>>,
-}
-
-impl WhipPeerDiagnostics {
-    pub fn set_sdp_summaries(&self, local: String, remote: String) {
-        if let Ok(mut summary) = self.local_sdp_summary.lock() {
-            *summary = Some(local);
-        }
-        if let Ok(mut summary) = self.remote_sdp_summary.lock() {
-            *summary = Some(remote);
-        }
-    }
-
-    pub fn format(&self) -> String {
-        format!(
-            "connection_states=[{}], ice_connection_states=[{}], ice_gathering_states=[{}], signaling_states=[{}], local_sdp_summary=[{}], remote_sdp_summary=[{}]",
-            join_states(&self.connection_states),
-            join_states(&self.ice_connection_states),
-            join_states(&self.ice_gathering_states),
-            join_states(&self.signaling_states),
-            optional_summary(&self.local_sdp_summary),
-            optional_summary(&self.remote_sdp_summary),
-        )
-    }
-}
-
-fn push_state(states: &Mutex<Vec<String>>, state: impl std::fmt::Display) {
-    if let Ok(mut states) = states.lock() {
-        states.push(state.to_string());
-    }
-}
-
-fn join_states(states: &Mutex<Vec<String>>) -> String {
-    states
-        .lock()
-        .map(|states| states.join(" -> "))
-        .unwrap_or_else(|_| "<poisoned>".to_string())
-}
-
-fn optional_summary(summary: &Mutex<Option<String>>) -> String {
-    summary
-        .lock()
-        .map(|summary| {
-            summary
-                .as_deref()
-                .unwrap_or("<not captured>")
-                .replace('\n', " | ")
-        })
-        .unwrap_or_else(|_| "<poisoned>".to_string())
-}
-
-#[async_trait::async_trait]
-impl PeerConnectionEventHandler for WhipPeerHandler {
-    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
-        info!("WHIP connection state changed: {}", state);
-        push_state(&self.diagnostics.connection_states, state);
-        let _ = self.state_tx.send(state);
-    }
-
-    async fn on_ice_connection_state_change(&self, state: RTCIceConnectionState) {
-        info!("WHIP ICE connection state changed: {}", state);
-        push_state(&self.diagnostics.ice_connection_states, state);
-    }
-
-    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
-        info!("WHIP ICE gathering state changed: {}", state);
-        push_state(&self.diagnostics.ice_gathering_states, state);
-        if state == RTCIceGatheringState::Complete {
-            info!("WHIP ICE gathering complete");
-            self.gather_complete.notify_one();
-        }
-    }
-
-    async fn on_signaling_state_change(&self, state: RTCSignalingState) {
-        info!("WHIP signaling state changed: {}", state);
-        push_state(&self.diagnostics.signaling_states, state);
-    }
+    Ok((
+        peer,
+        video_tx,
+        audio_tx,
+        stats,
+        publish.state_rx,
+        publish.diagnostics,
+    ))
 }
 
 fn is_supported_audio_codec(codec: &str) -> bool {
@@ -258,68 +109,5 @@ pub(crate) fn log_rtcp_feedback_packet(source: &str, packet: &dyn rtc_rtcp::pack
         debug!("{source}: received RTCP FIR");
     } else if any.downcast_ref::<TransportLayerNack>().is_some() {
         debug!("{source}: received RTCP NACK");
-    }
-}
-
-pub async fn format_ice_stats(peer: Arc<dyn PeerConnection>) -> String {
-    let report = peer
-        .get_stats(std::time::Instant::now(), StatsSelector::None)
-        .await;
-    let mut lines = Vec::new();
-
-    for entry in report.iter() {
-        match entry {
-            RTCStatsReportEntry::IceCandidatePair(pair) => {
-                lines.push(format!(
-                    "candidate_pair id={} local={} remote={} state={:?} nominated={} packets_sent={} packets_received={} bytes_sent={} bytes_received={} requests_sent={} requests_received={} responses_sent={} responses_received={}",
-                    pair.stats.id,
-                    pair.local_candidate_id,
-                    pair.remote_candidate_id,
-                    pair.state,
-                    pair.nominated,
-                    pair.packets_sent,
-                    pair.packets_received,
-                    pair.bytes_sent,
-                    pair.bytes_received,
-                    pair.requests_sent,
-                    pair.requests_received,
-                    pair.responses_sent,
-                    pair.responses_received,
-                ));
-            }
-            RTCStatsReportEntry::LocalCandidate(candidate) => {
-                lines.push(format!(
-                    "local_candidate id={} address={} port={} protocol={} type={:?} foundation={} related={}:{}",
-                    candidate.stats.id,
-                    candidate.address.as_deref().unwrap_or("<redacted>"),
-                    candidate.port,
-                    candidate.protocol,
-                    candidate.candidate_type,
-                    candidate.foundation,
-                    candidate.related_address,
-                    candidate.related_port,
-                ));
-            }
-            RTCStatsReportEntry::RemoteCandidate(candidate) => {
-                lines.push(format!(
-                    "remote_candidate id={} address={} port={} protocol={} type={:?} foundation={} related={}:{}",
-                    candidate.stats.id,
-                    candidate.address.as_deref().unwrap_or("<redacted>"),
-                    candidate.port,
-                    candidate.protocol,
-                    candidate.candidate_type,
-                    candidate.foundation,
-                    candidate.related_address,
-                    candidate.related_port,
-                ));
-            }
-            _ => {}
-        }
-    }
-
-    if lines.is_empty() {
-        "<no ice candidate stats>".to_string()
-    } else {
-        lines.join("; ")
     }
 }

--- a/livetwo/src/whipsynth/mod.rs
+++ b/livetwo/src/whipsynth/mod.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use anyhow::{Context, Result, anyhow};
+
 pub mod loadtest;
 pub mod packetizer;
 pub mod publisher;
@@ -10,6 +12,8 @@ pub use packetizer::{Packetizer, PacketizerConfig};
 pub use publisher::{Publisher, PublisherConfig};
 pub use source::SourceHandle;
 
+use crate::source::{AudioCodec, VideoCodec};
+
 /// Runtime statistics for a WHIP publisher session.
 #[derive(Debug, Clone, Default)]
 pub struct SessionStats {
@@ -19,4 +23,150 @@ pub struct SessionStats {
     pub nack_count: u64,
     pub pli_count: u64,
     pub connected_duration: Duration,
+}
+
+/// Parse a synthetic input URL into a [`Publisher`].
+///
+/// Returns `Ok(None)` when `input` is not a `synth://` URL, so callers can
+/// fall through to the RTP/RTSP input path.
+///
+/// Format: `synth://<vcodec>?audio=<acodec>&width=<px>&height=<px>&fps=<n>&duration=<secs>&stun=<url>`
+/// Example: `synth://h264?audio=opus&width=1280&height=720&fps=30`
+pub fn publisher_from_input(
+    input: &str,
+    whip_url: String,
+    token: Option<String>,
+) -> Result<Option<Publisher>> {
+    let prefix = format!("{}://", crate::SCHEME_SYNTH);
+    if !input.starts_with(&prefix) {
+        return Ok(None);
+    }
+
+    let url =
+        url::Url::parse(input).with_context(|| format!("Invalid synthetic input URL: {input}"))?;
+
+    let vcodec_name = url.host_str().unwrap_or_default();
+    let video_cli = cli::codec_from_str(vcodec_name).with_context(|| {
+        format!("Invalid synth video codec: '{vcodec_name}' (expected vp8, vp9, h264, h265, av1)")
+    })?;
+    let video_codec = VideoCodec::from_cli(video_cli)
+        .ok_or_else(|| anyhow!("Unsupported synth video codec: {vcodec_name}"))?;
+
+    let mut config = PublisherConfig {
+        whip_url,
+        token,
+        video_codec,
+        audio_codec: None,
+        width: 640,
+        height: 480,
+        fps: 30,
+        duration: None,
+        stun_server: crate::whip::core::DEFAULT_STUN_SERVER.to_string(),
+    };
+
+    for (key, value) in url.query_pairs() {
+        match key.as_ref() {
+            "audio" => {
+                let audio_cli = cli::codec_from_str(&value).with_context(|| {
+                    format!("Invalid synth audio codec: '{value}' (expected opus, g722)")
+                })?;
+                config.audio_codec = Some(
+                    AudioCodec::from_cli(audio_cli)
+                        .ok_or_else(|| anyhow!("Unsupported synth audio codec: {value}"))?,
+                );
+            }
+            "width" => {
+                config.width = value
+                    .parse()
+                    .with_context(|| format!("Invalid synth width: '{value}'"))?;
+            }
+            "height" => {
+                config.height = value
+                    .parse()
+                    .with_context(|| format!("Invalid synth height: '{value}'"))?;
+            }
+            "fps" => {
+                config.fps = value
+                    .parse()
+                    .with_context(|| format!("Invalid synth fps: '{value}'"))?;
+            }
+            "duration" => {
+                config.duration =
+                    Some(Duration::from_secs(value.parse().with_context(|| {
+                        format!("Invalid synth duration: '{value}'")
+                    })?));
+            }
+            "stun" => config.stun_server = value.into_owned(),
+            other => anyhow::bail!("Unknown synth input parameter: '{other}'"),
+        }
+    }
+
+    Ok(Some(Publisher::new(config)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_synth_input_returns_none() {
+        assert!(
+            publisher_from_input(
+                "sdp://0.0.0.0:5004/test.sdp",
+                "http://x/whip/1".into(),
+                None
+            )
+            .unwrap()
+            .is_none()
+        );
+        assert!(
+            publisher_from_input("rtsp://127.0.0.1:8554/cam", "http://x/whip/1".into(), None)
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn synth_input_parses_all_parameters() {
+        let config = publisher_from_input(
+            "synth://h264?audio=opus&width=1280&height=720&fps=30&duration=10&stun=stun:example.com:3478",
+            "http://x/whip/1".into(),
+            Some("tok".into()),
+        )
+        .unwrap()
+        .expect("synth input should produce a publisher")
+        .config_for_test();
+
+        assert_eq!(config.video_codec, VideoCodec::H264);
+        assert_eq!(config.audio_codec, Some(AudioCodec::Opus));
+        assert_eq!((config.width, config.height, config.fps), (1280, 720, 30));
+        assert_eq!(config.duration, Some(Duration::from_secs(10)));
+        assert_eq!(config.stun_server, "stun:example.com:3478");
+    }
+
+    #[test]
+    fn synth_input_defaults() {
+        let config = publisher_from_input("synth://vp8", "http://x/whip/1".into(), None)
+            .unwrap()
+            .expect("synth input should produce a publisher")
+            .config_for_test();
+
+        assert_eq!(config.video_codec, VideoCodec::Vp8);
+        assert_eq!(config.audio_codec, None);
+        assert_eq!((config.width, config.height, config.fps), (640, 480, 30));
+        assert_eq!(config.duration, None);
+        assert_eq!(config.stun_server, crate::whip::core::DEFAULT_STUN_SERVER);
+    }
+
+    #[test]
+    fn synth_input_rejects_bad_codec_and_unknown_param() {
+        assert!(
+            publisher_from_input("synth://mjpeg", "http://x/whip/1".into(), None).is_err(),
+            "non-synthetic codec must be rejected"
+        );
+        assert!(
+            publisher_from_input("synth://vp8?bogus=1", "http://x/whip/1".into(), None).is_err(),
+            "unknown parameter must be rejected"
+        );
+    }
 }

--- a/livetwo/src/whipsynth/publisher.rs
+++ b/livetwo/src/whipsynth/publisher.rs
@@ -3,33 +3,24 @@ use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow};
 use libwish::Client;
-use rtc::peer_connection::configuration::interceptor_registry::{
-    configure_nack, configure_rtcp_reports, configure_simulcast_extension_headers, configure_twcc,
-};
-use rtc::peer_connection::configuration::media_engine::{
-    MIME_TYPE_AV1, MIME_TYPE_HEVC, MediaEngine,
-};
-use rtc::rtp_transceiver::rtp_sender::{RTCRtpCodec, RTCRtpCodecParameters, RtpCodecKind};
+use rtc::peer_connection::configuration::media_engine::{MIME_TYPE_AV1, MIME_TYPE_HEVC};
+use rtc::rtp_transceiver::rtp_sender::{RTCRtpCodec, RTCRtpCodecParameters};
 use rtc::statistics::StatsSelector;
-use tokio::sync::{Notify, watch};
+use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 use webrtc::media_stream::Track;
 use webrtc::media_stream::track_local::TrackLocal;
 use webrtc::media_stream::track_local::static_rtp::TrackLocalStaticRTP;
-use webrtc::peer_connection::{
-    PeerConnection, PeerConnectionBuilder, PeerConnectionEventHandler, RTCConfigurationBuilder,
-    RTCIceConnectionState, RTCIceGatheringState, RTCIceServer, RTCPeerConnectionState,
-    RTCSignalingState, Registry,
-};
+use webrtc::peer_connection::PeerConnection;
 
 use crate::source::{AudioCodec, MediaFrame, VideoCodec, extract_h265_sprop};
 use crate::utils;
+use crate::utils::shutdown::graceful_shutdown;
+use crate::whip::core::{self, PublishPeerOptions};
 use crate::whipsynth::SessionStats;
 use crate::whipsynth::packetizer::{Packetizer, PacketizerConfig, VIDEO_RTCP_FEEDBACK};
 use crate::whipsynth::source::{frame_generator_config, spawn_rsmpeg_source};
-
-const WAIT_FOR_PEER_CONNECTED_TIMEOUT: Duration = Duration::from_secs(15);
 
 /// Configuration for a [`Publisher`].
 #[derive(Debug, Clone)]
@@ -58,6 +49,11 @@ impl Publisher {
         Self { config }
     }
 
+    #[cfg(test)]
+    pub(crate) fn config_for_test(&self) -> PublisherConfig {
+        self.config.clone()
+    }
+
     /// Run the publisher until cancelled or the configured duration expires.
     ///
     /// Returns the final session statistics on success.
@@ -69,9 +65,34 @@ impl Publisher {
             Client::get_auth_header_map(self.config.token.clone()),
         );
 
+        // Compute codec-specific SDP parameters up front so they can be used
+        // both for the offer (extra MediaEngine codec registrations) and for
+        // the packetizer's track metadata.
+        let extra_video_codecs = extra_video_codecs(&self.config);
+
         let gather_complete = Arc::new(Notify::new());
-        let (peer, mut packetizer, state_rx, diagnostics) =
-            create_peer(&self.config, gather_complete.clone(), ct.clone()).await?;
+        let publish = core::create_publish_peer(
+            ct.clone(),
+            gather_complete.clone(),
+            PublishPeerOptions {
+                stun_server: Some(self.config.stun_server.clone()),
+                extra_video_codecs,
+                cancel_on_failure: true,
+            },
+        )
+        .await?;
+        let peer = publish.peer;
+        let state_rx = publish.state_rx;
+        let diagnostics = publish.diagnostics;
+
+        let h265_sprop = h265_sprop(&self.config);
+        let mut packetizer_config =
+            PacketizerConfig::new(self.config.video_codec, self.config.audio_codec);
+        packetizer_config.width = self.config.width;
+        packetizer_config.height = self.config.height;
+        packetizer_config.fps = self.config.fps;
+        packetizer_config.h265_sprop = h265_sprop;
+        let mut packetizer = Packetizer::new(&packetizer_config)?;
 
         let video_track = packetizer
             .video_track(&input_id)
@@ -90,22 +111,21 @@ impl Publisher {
 
         info!("WHIP publisher peer created; starting signaling");
         utils::webrtc::setup_connection(peer.clone(), &mut client, gather_complete).await?;
-        info!(
-            "Local SDP offer summary:\n{}",
-            peer.local_description()
-                .await
-                .map(|description| utils::webrtc::summarize_sdp(&description.sdp))
-                .unwrap_or_else(|| "<no local description>".to_string())
-        );
-        info!(
-            "Remote SDP answer summary:\n{}",
-            peer.remote_description()
-                .await
-                .map(|description| utils::webrtc::summarize_sdp(&description.sdp))
-                .unwrap_or_else(|| "<no remote description>".to_string())
-        );
+        let local_summary = peer
+            .local_description()
+            .await
+            .map(|description| utils::webrtc::summarize_sdp(&description.sdp))
+            .unwrap_or_else(|| "<no local description>".to_string());
+        let remote_summary = peer
+            .remote_description()
+            .await
+            .map(|description| utils::webrtc::summarize_sdp(&description.sdp))
+            .unwrap_or_else(|| "<no remote description>".to_string());
+        info!("Local SDP offer summary:\n{}", local_summary);
+        info!("Remote SDP answer summary:\n{}", remote_summary);
+        diagnostics.set_sdp_summaries(local_summary, remote_summary);
 
-        wait_for_peer_connected(peer.clone(), state_rx.clone(), diagnostics.clone()).await?;
+        core::wait_for_peer_connected(peer.clone(), state_rx.clone(), diagnostics.clone()).await?;
         info!("WHIP publisher peer connected");
 
         // After SDP negotiation the answer may have remapped the dynamic payload
@@ -140,7 +160,7 @@ impl Publisher {
                 info!("Shutdown signal received, stopping WHIP publisher");
                 Ok(())
             }
-            result = wait_for_unexpected_peer_end(peer.clone(), state_rx, diagnostics.clone()) => {
+            result = core::wait_for_unexpected_peer_end(peer.clone(), state_rx, diagnostics.clone()) => {
                 ct.cancel();
                 result
             }
@@ -161,12 +181,7 @@ impl Publisher {
         if let Err(e) = &source_result {
             error!(error = ?e, "WHIP publisher source task failed");
         }
-        if let Err(e) = peer.close().await {
-            warn!("Failed to close WHIP publisher peer: {}", e);
-        }
-        if let Err(e) = client.remove_resource().await {
-            debug!("Failed to remove WHIP resource: {}", e);
-        }
+        graceful_shutdown("WHIP publisher", &mut client, peer).await;
 
         let mut final_stats = stats.lock().map(|s| s.clone()).unwrap_or_default();
         final_stats.nack_count = rtcp_feedback.nack_count;
@@ -184,6 +199,55 @@ impl Publisher {
         // Propagate peer/write-loop errors first, then source errors.
         result.and(source_result).map(|_| final_stats)
     }
+}
+
+/// H265 sprop parameters for the configured stream, when applicable.
+fn h265_sprop(config: &PublisherConfig) -> Option<String> {
+    (config.video_codec == VideoCodec::H265)
+        .then(|| extract_h265_sprop(config.width, config.height, config.fps))
+        .flatten()
+}
+
+/// Extra video codec registrations for the MediaEngine, applied before the
+/// default codecs so the generated SDP offer prefers them.
+///
+/// - H265: browsers such as Safari need the sprop-VPS/SPS/PPS in the offer to
+///   initialize an H265 WebRTC receiver.
+/// - AV1: without a resolution-derived level-idx the offer only advertises
+///   `profile-id=0` and the receiver infers level-idx=5 (720p30);
+///   higher-resolution streams may then be dropped once they exceed that level.
+fn extra_video_codecs(config: &PublisherConfig) -> Vec<RTCRtpCodecParameters> {
+    let mut codecs = Vec::new();
+
+    if let Some(sprop) = h265_sprop(config) {
+        codecs.push(RTCRtpCodecParameters {
+            rtp_codec: RTCRtpCodec {
+                mime_type: MIME_TYPE_HEVC.to_owned(),
+                clock_rate: 90_000,
+                channels: 0,
+                sdp_fmtp_line: sprop,
+                rtcp_feedback: VIDEO_RTCP_FEEDBACK.clone(),
+            },
+            payload_type: 126,
+        });
+    }
+
+    if config.video_codec == VideoCodec::Av1 {
+        let level_idx =
+            crate::whipsynth::packetizer::av1_level_idx(config.width, config.height, config.fps);
+        codecs.push(RTCRtpCodecParameters {
+            rtp_codec: RTCRtpCodec {
+                mime_type: MIME_TYPE_AV1.to_owned(),
+                clock_rate: 90_000,
+                channels: 0,
+                sdp_fmtp_line: format!("profile-id=0;level-idx={level_idx};tier=0"),
+                rtcp_feedback: VIDEO_RTCP_FEEDBACK.clone(),
+            },
+            payload_type: 41,
+        });
+    }
+
+    codecs
 }
 
 /// Pull the negotiated payload types from the peer's RTP senders and apply
@@ -304,118 +368,6 @@ async fn write_packets(
     }
 }
 
-async fn create_peer(
-    config: &PublisherConfig,
-    gather_complete: Arc<Notify>,
-    ct: CancellationToken,
-) -> Result<(
-    Arc<dyn PeerConnection>,
-    Packetizer,
-    watch::Receiver<RTCPeerConnectionState>,
-    Arc<PublisherDiagnostics>,
-)> {
-    let mut m = MediaEngine::default();
-
-    // Compute H265 sprop parameters up front so we can use them both for the
-    // SDP offer (via the MediaEngine) and for the track codec metadata.
-    let h265_sprop = (config.video_codec == VideoCodec::H265)
-        .then(|| extract_h265_sprop(config.width, config.height, config.fps))
-        .flatten();
-
-    // Register a custom H265 codec with sprop parameters before the defaults so
-    // the generated SDP offer includes them. Browsers such as Safari need the
-    // sprop-VPS/SPS/PPS in the offer to initialize an H265 WebRTC receiver.
-    if let Some(ref sprop) = h265_sprop {
-        m.register_codec(
-            RTCRtpCodecParameters {
-                rtp_codec: RTCRtpCodec {
-                    mime_type: MIME_TYPE_HEVC.to_owned(),
-                    clock_rate: 90_000,
-                    channels: 0,
-                    sdp_fmtp_line: sprop.clone(),
-                    rtcp_feedback: VIDEO_RTCP_FEEDBACK.clone(),
-                },
-                payload_type: 126,
-            },
-            RtpCodecKind::Video,
-        )?;
-    }
-
-    // Register a custom AV1 codec with a resolution-derived level-idx before the
-    // defaults so the generated SDP offer accurately describes the SVT-AV1
-    // stream. Without this the offer only advertises `profile-id=0` and the
-    // receiver infers level-idx=5 (720p30); higher-resolution streams may then
-    // be dropped once they exceed that level.
-    if config.video_codec == VideoCodec::Av1 {
-        let level_idx =
-            crate::whipsynth::packetizer::av1_level_idx(config.width, config.height, config.fps);
-        m.register_codec(
-            RTCRtpCodecParameters {
-                rtp_codec: RTCRtpCodec {
-                    mime_type: MIME_TYPE_AV1.to_owned(),
-                    clock_rate: 90_000,
-                    channels: 0,
-                    sdp_fmtp_line: format!("profile-id=0;level-idx={level_idx};tier=0"),
-                    rtcp_feedback: VIDEO_RTCP_FEEDBACK.clone(),
-                },
-                payload_type: 41,
-            },
-            RtpCodecKind::Video,
-        )?;
-    }
-
-    m.register_default_codecs()?;
-
-    let registry = Registry::new();
-    let registry = configure_nack(registry, &mut m);
-    let registry = configure_rtcp_reports(registry);
-    configure_simulcast_extension_headers(&mut m)?;
-    let registry = configure_twcc(registry, &mut m)?;
-    info!("WHIP publisher configured with NACK, RTCP reports, and TWCC");
-
-    let mut packetizer_config = PacketizerConfig::new(config.video_codec, config.audio_codec);
-    packetizer_config.width = config.width;
-    packetizer_config.height = config.height;
-    packetizer_config.fps = config.fps;
-    packetizer_config.h265_sprop = h265_sprop;
-    let packetizer = Packetizer::new(&packetizer_config)?;
-
-    let (state_tx, state_rx) = watch::channel(RTCPeerConnectionState::New);
-    let diagnostics = Arc::new(PublisherDiagnostics::default());
-    let handler: Arc<dyn PeerConnectionEventHandler> = Arc::new(PublisherHandler {
-        ct,
-        gather_complete,
-        state_tx,
-        diagnostics: diagnostics.clone(),
-    });
-
-    let ice_config = if config.stun_server.trim().is_empty() {
-        RTCConfigurationBuilder::new().build()
-    } else {
-        RTCConfigurationBuilder::new()
-            .with_ice_servers(vec![RTCIceServer {
-                urls: vec![config.stun_server.clone()],
-                username: "".to_string(),
-                credential: "".to_string(),
-            }])
-            .build()
-    };
-
-    let peer: Arc<dyn PeerConnection> = Arc::new(
-        PeerConnectionBuilder::new()
-            .with_media_engine(m)
-            .with_interceptor_registry(registry)
-            .with_handler(handler)
-            .with_udp_addrs(utils::webrtc::ice_udp_addrs())
-            .with_configuration(ice_config)
-            .build()
-            .await
-            .map_err(|error| anyhow!("{:?}: {}", error, error))?,
-    );
-
-    Ok((peer, packetizer, state_rx, diagnostics))
-}
-
 #[derive(Default, Clone, Copy)]
 struct RtcpFeedbackCounters {
     nack_count: u64,
@@ -432,168 +384,4 @@ async fn collect_rtcp_feedback(peer: &Arc<dyn PeerConnection>) -> RtcpFeedbackCo
         counters.pli_count += outbound.pli_count as u64;
     }
     counters
-}
-
-async fn wait_for_peer_connected(
-    peer: Arc<dyn PeerConnection>,
-    mut state_rx: watch::Receiver<RTCPeerConnectionState>,
-    diagnostics: Arc<PublisherDiagnostics>,
-) -> Result<()> {
-    let result = tokio::time::timeout(WAIT_FOR_PEER_CONNECTED_TIMEOUT, async {
-        loop {
-            let state = *state_rx.borrow_and_update();
-            match state {
-                RTCPeerConnectionState::Connected => return Ok(()),
-                RTCPeerConnectionState::Failed
-                | RTCPeerConnectionState::Closed
-                | RTCPeerConnectionState::Disconnected => {
-                    return Err(anyhow!(
-                        "WHIP publisher peer connection ended before becoming connected: state={state}"
-                    ));
-                }
-                _ => {}
-            }
-
-            state_rx
-                .changed()
-                .await
-                .map_err(|_| anyhow!("WHIP publisher peer connection state channel closed"))?;
-        }
-    })
-    .await;
-
-    match result {
-        Ok(Ok(())) => Ok(()),
-        Ok(Err(error)) => {
-            let ice_stats = crate::whip::format_ice_stats(peer).await;
-            Err(anyhow!(
-                "{error}, {}, ice_stats=[{}]",
-                diagnostics.format(),
-                ice_stats
-            ))
-        }
-        Err(_) => {
-            let ice_stats = crate::whip::format_ice_stats(peer).await;
-            Err(anyhow!(
-                "WHIP publisher peer connection timed out waiting for connected after {:?}: {}, ice_stats=[{}]",
-                WAIT_FOR_PEER_CONNECTED_TIMEOUT,
-                diagnostics.format(),
-                ice_stats
-            ))
-        }
-    }
-}
-
-async fn wait_for_unexpected_peer_end(
-    peer: Arc<dyn PeerConnection>,
-    mut state_rx: watch::Receiver<RTCPeerConnectionState>,
-    diagnostics: Arc<PublisherDiagnostics>,
-) -> Result<()> {
-    let mut saw_connected = *state_rx.borrow() == RTCPeerConnectionState::Connected;
-
-    loop {
-        let state = *state_rx.borrow();
-        if state == RTCPeerConnectionState::Connected {
-            saw_connected = true;
-        }
-
-        if matches!(
-            state,
-            RTCPeerConnectionState::Failed
-                | RTCPeerConnectionState::Closed
-                | RTCPeerConnectionState::Disconnected
-        ) {
-            let ice_stats = crate::whip::format_ice_stats(peer).await;
-            return Err(anyhow!(
-                "WHIP publisher peer connection ended before shutdown: state={state}, connected_before={saw_connected}, {}, ice_stats=[{}]",
-                diagnostics.format(),
-                ice_stats
-            ));
-        }
-
-        state_rx
-            .changed()
-            .await
-            .map_err(|_| anyhow!("WHIP publisher peer connection state channel closed"))?;
-    }
-}
-
-#[derive(Default)]
-pub struct PublisherDiagnostics {
-    connection_states: Mutex<Vec<String>>,
-    ice_connection_states: Mutex<Vec<String>>,
-    ice_gathering_states: Mutex<Vec<String>>,
-    signaling_states: Mutex<Vec<String>>,
-}
-
-impl PublisherDiagnostics {
-    pub fn format(&self) -> String {
-        format!(
-            "connection_states=[{}], ice_connection_states=[{}], ice_gathering_states=[{}], signaling_states=[{}]",
-            join_states(&self.connection_states),
-            join_states(&self.ice_connection_states),
-            join_states(&self.ice_gathering_states),
-            join_states(&self.signaling_states),
-        )
-    }
-}
-
-fn join_states(states: &Mutex<Vec<String>>) -> String {
-    states
-        .lock()
-        .map(|s| s.join(" -> "))
-        .unwrap_or_else(|poisoned| format!("{}(poisoned)", poisoned.into_inner().join(" -> ")))
-}
-
-fn push_state(states: &Mutex<Vec<String>>, state: impl std::fmt::Display) {
-    match states.lock() {
-        Ok(mut states) => states.push(state.to_string()),
-        Err(poisoned) => {
-            // Recover the inner data after a panic so diagnostics are still
-            // available for error reporting.
-            let mut states = poisoned.into_inner();
-            states.push(state.to_string());
-        }
-    }
-}
-
-struct PublisherHandler {
-    ct: CancellationToken,
-    gather_complete: Arc<Notify>,
-    state_tx: watch::Sender<RTCPeerConnectionState>,
-    diagnostics: Arc<PublisherDiagnostics>,
-}
-
-#[async_trait::async_trait]
-impl PeerConnectionEventHandler for PublisherHandler {
-    async fn on_connection_state_change(&self, state: RTCPeerConnectionState) {
-        info!("WHIP publisher connection state changed: {}", state);
-        push_state(&self.diagnostics.connection_states, state);
-        let _ = self.state_tx.send(state);
-        if matches!(
-            state,
-            RTCPeerConnectionState::Failed | RTCPeerConnectionState::Closed
-        ) {
-            self.ct.cancel();
-        }
-    }
-
-    async fn on_ice_connection_state_change(&self, state: RTCIceConnectionState) {
-        info!("WHIP publisher ICE connection state changed: {}", state);
-        push_state(&self.diagnostics.ice_connection_states, state);
-    }
-
-    async fn on_ice_gathering_state_change(&self, state: RTCIceGatheringState) {
-        info!("WHIP publisher ICE gathering state changed: {}", state);
-        push_state(&self.diagnostics.ice_gathering_states, state);
-        if state == RTCIceGatheringState::Complete {
-            info!("WHIP publisher ICE gathering complete");
-            self.gather_complete.notify_one();
-        }
-    }
-
-    async fn on_signaling_state_change(&self, state: RTCSignalingState) {
-        info!("WHIP publisher signaling state changed: {}", state);
-        push_state(&self.diagnostics.signaling_states, state);
-    }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -171,6 +171,83 @@ async fn test_liveion_stream_create() {
     assert_eq!(1, body.len());
 }
 
+#[cfg(feature = "rsmpeg")]
+#[tokio::test]
+async fn test_livetwo_whipinto_synth_input() {
+    init_liveion_test_environment();
+
+    let cfg = liveion::config::Config::default();
+    let ip = IpAddr::V4(Ipv4Addr::LOCALHOST);
+
+    let listener = TcpListener::bind(SocketAddr::new(ip, 0)).await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(liveion::serve(cfg, listener, shutdown_signal()));
+
+    let res = reqwest::Client::new()
+        .post(format!("http://{addr}{}", api::path::streams("-")))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(http::StatusCode::NO_CONTENT, res.status());
+
+    // Publish an in-process synthetic stream through the unified `whip::into`
+    // entry point, the same path `whipinto --input synth://...` uses.
+    // `stun=` (empty) disables ICE servers so the test stays on loopback.
+    let ct = CancellationToken::new();
+    let handle_whip = tokio::spawn(livetwo::whip::into(
+        ct.clone(),
+        "synth://vp8?width=320&height=240&fps=15&duration=30&stun=".to_string(),
+        format!("http://{addr}{}", api::path::whip("-")),
+        None,
+        None,
+    ));
+
+    let mut result = None;
+    let mut last_publish_state = None;
+    for _ in 0..CONNECTION_WAIT_ATTEMPTS {
+        let res = reqwest::get(format!("http://{addr}{}", api::path::streams("")))
+            .await
+            .unwrap();
+
+        assert_eq!(http::StatusCode::OK, res.status());
+
+        let body = res.json::<Vec<api::response::Stream>>().await.unwrap();
+
+        if let Some(r) = body.into_iter().find(|i| i.id == "-")
+            && !r.publish.sessions.is_empty()
+        {
+            let s = r.publish.sessions[0].clone();
+            last_publish_state = Some(s.state);
+            if s.state == api::response::RTCPeerConnectionState::Connected {
+                result = Some(s);
+                break;
+            }
+        };
+
+        if handle_whip.is_finished() {
+            let result_whip = handle_whip.await.unwrap();
+            panic!(
+                "synth WHIP task exited before publish connected: result={result_whip:?}, last_state={last_publish_state:?}"
+            );
+        }
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    }
+
+    assert!(
+        result.is_some(),
+        "Synth publish session did not reach Connected within {}ms: last_state={last_publish_state:?}",
+        CONNECTION_WAIT_ATTEMPTS * 100,
+    );
+
+    ct.cancel();
+
+    let result_whip = handle_whip.await.unwrap();
+    assert!(result_whip.is_ok());
+}
+
 #[tokio::test]
 async fn test_liveion_stream_connect() {
     init_liveion_test_environment();


### PR DESCRIPTION
## Summary

Extract a single WHIP publish core (`livetwo/src/whip/core.rs`) shared by the RTP/RTSP bridge (`whip::into`) and the synthetic whipsynth publisher: peer construction with extra codec registrations, connection-state waits, ICE diagnostics and ICE stats formatting now live in one place instead of two divergent copies.

whipinto gains a `synth://<vcodec>?...` input (rsmpeg feature) that publishes in-process generated frames directly:

```bash
whipinto -i 'synth://h264?audio=opus&width=1280&duration=10' -w http://localhost:7777/whip/777
```

- Publisher keeps the SessionStats/loadtest API; teardown uses the shared graceful_shutdown helper
- Behavior preserved per caller via PublishPeerOptions (stun server, extra codecs, cancel-on-failure)
- `publisher_from_input` URL parsing unit tests + an end-to-end synth input integration test

## Test plan

- [x] livetwo unit tests 52/52 (incl. moved core tests)
- [x] integration `tests` binary 7/7 (incl. new synth input case)
- [x] whipsynth matrix 10/10 (vp8/h264/h265/av1 + audio combos)
- [x] rtp/rtsp smoke (whip::into path, no regression)
- [x] CI green on ubuntu-26.04 / macOS / Windows