### PR TITLE
feat(livetwo): add unified livetwo converter CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,11 +67,13 @@ Built from `src/bin/` or `src/<name>.rs` in the root crate:
 - `live777`      — main SFU server (uses `liveion`).
 - `liveman`      — cluster manager for multiple `live777` nodes.
 - `livecam`      — camera ingest server.
-- `livetwo`      — provided as a library; command tools below use it.
-- `whipinto`     — push RTP/RTSP into a WHIP endpoint; with the `rsmpeg`
-  feature it also accepts a `synth://<vcodec>?...` input that publishes
+- `livetwo`      — protocol-conversion library AND unified converter CLI
+  (`livetwo whip|whep|synth|probe`). With the `rsmpeg` feature the `whip`
+  subcommand also accepts a `synth://<vcodec>?...` input that publishes
   in-process generated test frames (no external encoder needed).
-- `whepfrom`     — pull a WHEP stream and output RTP/RTSP.
+- `whipinto`/`whepfrom`/`whipsynth`/`whepprobe` — thin legacy aliases of the
+  corresponding `livetwo` subcommands; all argument parsing and run logic
+  lives in `src/livetwo_cli.rs` and is shared by both spellings.
 - `whepwright`   — browser-based WHEP playback tester (feature gated).
 - `livevod`      — VOD/recording playback helper.
 - `net4mqtt`     — net-over-MQTT proxy binary.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,12 @@ name = "whepfrom"
 path = "src/whepfrom.rs"
 
 [[bin]]
+name = "livetwo"
+path = "src/livetwo.rs"
+test = false
+bench = false
+
+[[bin]]
 name = "whepprobe"
 path = "src/whepprobe.rs"
 required-features = ["rsmpeg"]

--- a/libs/rtsp/src/lib.rs
+++ b/libs/rtsp/src/lib.rs
@@ -25,7 +25,7 @@ pub use constants::{
 };
 pub use sdp::{
     extract_h264_params, extract_h265_params, filter_sdp, parse_codecs_from_sdp,
-    parse_media_info_from_sdp,
+    parse_media_info_from_sdp, parse_transports_from_sdp,
 };
 #[cfg(feature = "server")]
 pub use server::{

--- a/libs/rtsp/src/sdp.rs
+++ b/libs/rtsp/src/sdp.rs
@@ -7,7 +7,7 @@ use std::io::Cursor;
 use tracing::{debug, warn};
 
 use crate::constants::media_type;
-use crate::types::{AudioCodecParams, MediaInfo, VideoCodecParams};
+use crate::types::{AudioCodecParams, MediaInfo, TransportInfo, VideoCodecParams};
 
 pub fn parse_media_info_from_sdp(sdp_bytes: &[u8]) -> Result<MediaInfo> {
     let sdp =
@@ -21,6 +21,33 @@ pub fn parse_media_info_from_sdp(sdp_bytes: &[u8]) -> Result<MediaInfo> {
         video_transport: None,
         audio_transport: None,
     })
+}
+
+/// Derive UDP transport info from an SDP's `m=` lines.
+///
+/// Each media port becomes the RTP receive port and `port + 1` the RTCP
+/// receive port, matching the FFmpeg `-sdp_file` convention used by
+/// RTP/SDP-file listeners. Returns `(video_transport, audio_transport)`.
+pub fn parse_transports_from_sdp(
+    sdp: &sdp_types::Session,
+) -> (Option<TransportInfo>, Option<TransportInfo>) {
+    let transport_for = |kind: &str| {
+        sdp.medias
+            .iter()
+            .find(|media| media.media == kind)
+            .map(|media| TransportInfo::Udp {
+                rtp_send_port: None,
+                rtp_recv_port: Some(media.port),
+                rtcp_send_port: None,
+                rtcp_recv_port: Some(media.port + 1),
+                server_addr: None,
+            })
+    };
+
+    (
+        transport_for(media_type::VIDEO),
+        transport_for(media_type::AUDIO),
+    )
 }
 
 pub fn parse_codecs_from_sdp(

--- a/liveion/src/rtsp_codec.rs
+++ b/liveion/src/rtsp_codec.rs
@@ -1,6 +1,29 @@
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use rtc::rtp_transceiver::rtp_sender::{RTCRtpCodec, RTCRtpCodecParameters};
 
+/// Convert an audio codec announcement into a WebRTC codec description.
+///
+/// Shared by [`crate::stream::source::sdp_source`] and
+/// [`crate::stream::source::rtsp_source`].
+pub(crate) fn audio_codec_to_rtc(codec: &rtsp::AudioCodecParams) -> RTCRtpCodecParameters {
+    let mime_type = format!("audio/{}", codec.codec.to_uppercase());
+
+    RTCRtpCodecParameters {
+        rtp_codec: RTCRtpCodec {
+            mime_type,
+            clock_rate: codec.clock_rate,
+            channels: codec.channels,
+            sdp_fmtp_line: if codec.codec.to_lowercase() == "opus" {
+                "minptime=10;useinbandfec=1".to_string()
+            } else {
+                String::new()
+            },
+            rtcp_feedback: vec![],
+        },
+        payload_type: codec.payload_type,
+    }
+}
+
 /// Convert an RTSP video codec announcement into a WebRTC codec description.
 ///
 /// Shared between [`crate::rtsp_server`] (server-side SDP construction) and

--- a/liveion/src/stream/source/rtsp_source.rs
+++ b/liveion/src/stream/source/rtsp_source.rs
@@ -10,7 +10,7 @@ use tracing::{debug, error, info, trace, warn};
 use tokio::sync::mpsc;
 
 #[cfg(feature = "source")]
-use rtc::rtp_transceiver::rtp_sender::{RTCRtpCodec, RTCRtpCodecParameters};
+use rtc::rtp_transceiver::rtp_sender::RTCRtpCodecParameters;
 
 #[cfg(feature = "source")]
 type RtcpSender = Arc<RwLock<Option<mpsc::Sender<(u8, Vec<u8>)>>>>;
@@ -412,26 +412,6 @@ impl RtspSource {
     fn video_codec_to_rtc(codec: &rtsp::VideoCodecParams) -> RTCRtpCodecParameters {
         crate::rtsp_codec::video_codec_to_rtc(codec)
     }
-
-    #[cfg(feature = "source")]
-    fn audio_codec_to_rtc(codec: &rtsp::AudioCodecParams) -> RTCRtpCodecParameters {
-        let mime_type = format!("audio/{}", codec.codec.to_uppercase());
-
-        RTCRtpCodecParameters {
-            rtp_codec: RTCRtpCodec {
-                mime_type,
-                clock_rate: codec.clock_rate,
-                channels: codec.channels,
-                sdp_fmtp_line: if codec.codec.to_lowercase() == "opus" {
-                    "minptime=10;useinbandfec=1".to_string()
-                } else {
-                    String::new()
-                },
-                rtcp_feedback: vec![],
-            },
-            payload_type: codec.payload_type,
-        }
-    }
 }
 
 #[async_trait]
@@ -525,7 +505,7 @@ impl StreamSource for RtspSource {
             && let Some(ref info) = *media_info
             && let Some(ref audio_codec) = info.audio_codec
         {
-            return Some(Self::audio_codec_to_rtc(audio_codec));
+            return Some(crate::rtsp_codec::audio_codec_to_rtc(audio_codec));
         }
 
         None

--- a/liveion/src/stream/source/sdp_source.rs
+++ b/liveion/src/stream/source/sdp_source.rs
@@ -11,10 +11,7 @@ use tracing::{debug, error, info, trace};
 use tokio::sync::mpsc;
 
 #[cfg(feature = "source")]
-use rtc::rtp_transceiver::rtp_sender::RTCPFeedback;
-
-#[cfg(feature = "source")]
-use rtc::rtp_transceiver::rtp_sender::{RTCRtpCodec, RTCRtpCodecParameters};
+use rtc::rtp_transceiver::rtp_sender::RTCRtpCodecParameters;
 
 #[cfg(feature = "source")]
 type RtcpSender = Arc<RwLock<Option<mpsc::UnboundedSender<(SocketAddr, Vec<u8>)>>>>;
@@ -49,28 +46,10 @@ pub struct SdpSource {
 #[cfg(feature = "source")]
 #[derive(Clone, Debug)]
 struct SdpMediaInfo {
-    video_codec: Option<VideoCodecInfo>,
-    audio_codec: Option<AudioCodecInfo>,
+    video_codec: Option<rtsp::VideoCodecParams>,
+    audio_codec: Option<rtsp::AudioCodecParams>,
     video_rtcp_addr: Option<SocketAddr>,
     audio_rtcp_addr: Option<SocketAddr>,
-}
-
-#[cfg(feature = "source")]
-#[derive(Clone, Debug)]
-struct VideoCodecInfo {
-    codec_name: String,
-    clock_rate: u32,
-    payload_type: u8,
-    fmtp_line: Option<String>,
-}
-
-#[cfg(feature = "source")]
-#[derive(Clone, Debug)]
-struct AudioCodecInfo {
-    codec_name: String,
-    clock_rate: u32,
-    channels: u16,
-    payload_type: u8,
 }
 
 impl SdpSource {
@@ -138,10 +117,6 @@ impl SdpSource {
     fn parse_sdp(&self) -> Result<ParsedSdp> {
         let mut ports = Vec::new();
         let mut channel = 0u8;
-        let mut video_codec: Option<VideoCodecInfo> = None;
-        let mut audio_codec: Option<AudioCodecInfo> = None;
-        let mut current_media_type: Option<String> = None;
-        let mut current_payload_type: Option<u8> = None;
 
         let connection_info = self.parse_connection_address();
         let mut video_rtcp_addr: Option<SocketAddr> = None;
@@ -152,19 +127,18 @@ impl SdpSource {
             .map(|(_, ipv6)| *ipv6)
             .unwrap_or(false);
 
+        // Scan `m=` lines for media ports and derive RTCP addresses
+        // (port + 1) from the session connection address. Codec parsing is
+        // delegated to the shared libs/rtsp SDP parser below.
         for line in self.sdp_content.lines() {
             let line = line.trim();
 
             if line.starts_with("m=video") || line.starts_with("m=audio") {
                 let parts: Vec<&str> = line.split_whitespace().collect();
-                if parts.len() >= 4 {
+                if parts.len() >= 2 {
                     let media_type = parts[0].trim_start_matches("m=");
-                    current_media_type = Some(media_type.to_string());
 
-                    if let Ok(port) = parts[1].parse::<u16>()
-                        && let Ok(pt) = parts[3].parse::<u8>()
-                    {
-                        current_payload_type = Some(pt);
+                    if let Ok(port) = parts[1].parse::<u16>() {
                         ports.push((channel, port));
 
                         if let Some((ref addr, _)) = connection_info {
@@ -199,79 +173,10 @@ impl SdpSource {
                         channel += 2;
 
                         info!(
-                            "[{}] Found media: {} on port {} (PT={})",
-                            self.config.stream_id, media_type, port, pt
+                            "[{}] Found media: {} on port {}",
+                            self.config.stream_id, media_type, port
                         );
                     }
-                }
-            }
-
-            if line.starts_with("a=rtpmap:") {
-                let rtpmap = line.trim_start_matches("a=rtpmap:");
-                let parts: Vec<&str> = rtpmap.split_whitespace().collect();
-
-                if parts.len() >= 2
-                    && let Ok(pt) = parts[0].parse::<u8>()
-                    && Some(pt) == current_payload_type
-                {
-                    let codec_parts: Vec<&str> = parts[1].split('/').collect();
-
-                    if codec_parts.len() >= 2 {
-                        let codec_name = codec_parts[0].to_string();
-                        let clock_rate = codec_parts[1].parse::<u32>().unwrap_or(90000);
-
-                        match current_media_type.as_deref() {
-                            Some("video") => {
-                                video_codec = Some(VideoCodecInfo {
-                                    codec_name: codec_name.clone(),
-                                    clock_rate,
-                                    payload_type: pt,
-                                    fmtp_line: None,
-                                });
-                                info!(
-                                    "[{}] Parsed video codec: {} ({}Hz, PT={})",
-                                    self.config.stream_id, codec_name, clock_rate, pt
-                                );
-                            }
-                            Some("audio") => {
-                                let channels = if codec_parts.len() >= 3 {
-                                    codec_parts[2].parse::<u16>().unwrap_or(1)
-                                } else {
-                                    1
-                                };
-
-                                audio_codec = Some(AudioCodecInfo {
-                                    codec_name: codec_name.clone(),
-                                    clock_rate,
-                                    channels,
-                                    payload_type: pt,
-                                });
-                                info!(
-                                    "[{}] Parsed audio codec: {} ({}Hz, {} channels, PT={})",
-                                    self.config.stream_id, codec_name, clock_rate, channels, pt
-                                );
-                            }
-                            _ => {}
-                        }
-                    }
-                }
-            }
-
-            if line.starts_with("a=fmtp:") {
-                let fmtp = line.trim_start_matches("a=fmtp:");
-                if let Some((pt_str, params)) = fmtp.split_once(' ')
-                    && let Ok(pt) = pt_str.parse::<u8>()
-                    && Some(pt) == current_payload_type
-                    && let Some("video") = current_media_type.as_deref()
-                    && let Some(ref mut vc) = video_codec
-                {
-                    vc.fmtp_line = Some(params.trim().to_string());
-                    info!(
-                        "[{}] Parsed video fmtp for PT={}: {}",
-                        self.config.stream_id,
-                        pt,
-                        params.trim()
-                    );
                 }
             }
         }
@@ -280,9 +185,26 @@ impl SdpSource {
             anyhow::bail!("No valid media ports found in SDP");
         }
 
+        // Shared SDP codec parsing (libs/rtsp): keeps codec parameters such
+        // as H264 sprop-parameter-sets and H265 sprop-vps/sps/pps.
+        let parsed = rtsp::parse_media_info_from_sdp(self.sdp_content.as_bytes())?;
+
+        if let Some(ref codec) = parsed.video_codec {
+            info!(
+                "[{}] Parsed video codec: {:?}",
+                self.config.stream_id, codec
+            );
+        }
+        if let Some(ref codec) = parsed.audio_codec {
+            info!(
+                "[{}] Parsed audio codec: {:?}",
+                self.config.stream_id, codec
+            );
+        }
+
         let media_info = SdpMediaInfo {
-            video_codec,
-            audio_codec,
+            video_codec: parsed.video_codec,
+            audio_codec: parsed.audio_codec,
             video_rtcp_addr,
             audio_rtcp_addr,
         };
@@ -456,74 +378,17 @@ impl SdpSource {
     }
 
     #[cfg(feature = "source")]
-    fn video_codec_to_rtc(codec: &VideoCodecInfo) -> RTCRtpCodecParameters {
-        let mime_type = format!("video/{}", codec.codec_name.to_uppercase());
-        let codec_upper = codec.codec_name.to_uppercase();
-
-        let sdp_fmtp_line = if codec_upper == "H264" {
-            "level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f".to_string()
-        } else if codec_upper == "H265" || codec_upper == "HEVC" {
-            // Preserve any fmtp line from the source SDP; if none is present, use a
-            // default H.265 fmtp so browsers can negotiate the codec.
-            codec
-                .fmtp_line
-                .clone()
-                .unwrap_or_else(|| "profile-id=0;tier-flag=0;tx-mode=SRST".to_string())
-        } else {
-            String::new()
-        };
-
-        RTCRtpCodecParameters {
-            rtp_codec: RTCRtpCodec {
-                mime_type,
-                clock_rate: codec.clock_rate,
-                channels: 0,
-                sdp_fmtp_line,
-                rtcp_feedback: vec![
-                    RTCPFeedback {
-                        typ: "goog-remb".to_owned(),
-                        parameter: "".to_owned(),
-                    },
-                    RTCPFeedback {
-                        typ: "transport-cc".to_owned(),
-                        parameter: "".to_owned(),
-                    },
-                    RTCPFeedback {
-                        typ: "ccm".to_owned(),
-                        parameter: "fir".to_owned(),
-                    },
-                    RTCPFeedback {
-                        typ: "nack".to_owned(),
-                        parameter: "".to_owned(),
-                    },
-                    RTCPFeedback {
-                        typ: "nack".to_owned(),
-                        parameter: "pli".to_owned(),
-                    },
-                ],
-            },
-            payload_type: codec.payload_type,
+    fn video_codec_to_rtc(codec: &rtsp::VideoCodecParams) -> RTCRtpCodecParameters {
+        let mut params = crate::rtsp_codec::video_codec_to_rtc(codec);
+        // Keep the historical H265 browser fallback: when the source SDP
+        // carries no sprop parameters, offer a default H265 fmtp so browsers
+        // can negotiate the codec.
+        if matches!(codec, rtsp::VideoCodecParams::H265 { .. })
+            && params.rtp_codec.sdp_fmtp_line.is_empty()
+        {
+            params.rtp_codec.sdp_fmtp_line = "profile-id=0;tier-flag=0;tx-mode=SRST".to_string();
         }
-    }
-
-    #[cfg(feature = "source")]
-    fn audio_codec_to_rtc(codec: &AudioCodecInfo) -> RTCRtpCodecParameters {
-        let mime_type = format!("audio/{}", codec.codec_name.to_uppercase());
-
-        RTCRtpCodecParameters {
-            rtp_codec: RTCRtpCodec {
-                mime_type,
-                clock_rate: codec.clock_rate,
-                channels: codec.channels,
-                sdp_fmtp_line: if codec.codec_name.to_lowercase() == "opus" {
-                    "minptime=10;useinbandfec=1".to_string()
-                } else {
-                    String::new()
-                },
-                rtcp_feedback: vec![],
-            },
-            payload_type: codec.payload_type,
-        }
+        params
     }
 
     #[cfg(feature = "source")]
@@ -715,7 +580,7 @@ impl StreamSource for SdpSource {
             && let Some(ref info) = *media_info
             && let Some(ref audio_codec) = info.audio_codec
         {
-            return Some(Self::audio_codec_to_rtc(audio_codec));
+            return Some(crate::rtsp_codec::audio_codec_to_rtc(audio_codec));
         }
 
         None
@@ -731,16 +596,30 @@ impl StreamSource for SdpSource {
 mod tests {
     use super::*;
 
-    #[test]
-    fn h265_without_fmtp_gets_default_profile() {
-        let codec = VideoCodecInfo {
-            codec_name: "H265".to_string(),
-            clock_rate: 90000,
-            payload_type: 97,
-            fmtp_line: None,
-        };
+    fn test_source(sdp: &str) -> SdpSource {
+        SdpSource::new(
+            InternalSourceConfig {
+                stream_id: "test".to_string(),
+                url: "test.sdp".to_string(),
+            },
+            sdp.to_string(),
+        )
+        .unwrap()
+    }
 
-        let params = SdpSource::video_codec_to_rtc(&codec);
+    fn h265(vps: Vec<u8>, sps: Vec<u8>, pps: Vec<u8>) -> rtsp::VideoCodecParams {
+        rtsp::VideoCodecParams::H265 {
+            payload_type: 97,
+            clock_rate: 90000,
+            vps,
+            sps,
+            pps,
+        }
+    }
+
+    #[test]
+    fn h265_without_sprop_gets_default_profile() {
+        let params = SdpSource::video_codec_to_rtc(&h265(vec![], vec![], vec![]));
 
         assert_eq!(params.rtp_codec.mime_type, "video/H265");
         assert!(
@@ -756,29 +635,37 @@ mod tests {
     }
 
     #[test]
-    fn h265_with_fmtp_preserves_source_params() {
-        let codec = VideoCodecInfo {
-            codec_name: "H265".to_string(),
-            clock_rate: 90000,
-            payload_type: 97,
-            fmtp_line: Some("profile-id=1;tier-flag=0;tx-mode=SRST".to_string()),
-        };
+    fn h265_with_sprop_uses_sprop_fmtp() {
+        let params = SdpSource::video_codec_to_rtc(&h265(vec![1], vec![2], vec![3]));
 
-        let params = SdpSource::video_codec_to_rtc(&codec);
-
-        assert_eq!(
-            params.rtp_codec.sdp_fmtp_line,
-            "profile-id=1;tier-flag=0;tx-mode=SRST"
+        let fmtp = &params.rtp_codec.sdp_fmtp_line;
+        assert!(
+            fmtp.contains("sprop-vps=AQ=="),
+            "expected sprop-vps in fmtp, got {fmtp}"
+        );
+        assert!(
+            fmtp.contains("sprop-sps=Ag=="),
+            "expected sprop-sps in fmtp, got {fmtp}"
+        );
+        assert!(
+            fmtp.contains("sprop-pps=Aw=="),
+            "expected sprop-pps in fmtp, got {fmtp}"
+        );
+        assert!(
+            !fmtp.contains("tx-mode=SRST"),
+            "sprop present, default fallback must not apply: {fmtp}"
         );
     }
 
     #[test]
     fn h264_keeps_default_fmtp() {
-        let codec = VideoCodecInfo {
-            codec_name: "H264".to_string(),
-            clock_rate: 90000,
+        let codec = rtsp::VideoCodecParams::H264 {
             payload_type: 96,
-            fmtp_line: None,
+            clock_rate: 90000,
+            profile_level_id: None,
+            packetization_mode: None,
+            sps: vec![],
+            pps: vec![],
         };
 
         let params = SdpSource::video_codec_to_rtc(&codec);
@@ -789,5 +676,46 @@ mod tests {
                 .sdp_fmtp_line
                 .contains("profile-level-id=42001f")
         );
+        assert!(
+            params
+                .rtp_codec
+                .sdp_fmtp_line
+                .contains("packetization-mode=1")
+        );
+    }
+
+    #[test]
+    fn parses_ports_codecs_and_rtcp_with_shared_parser() {
+        let sdp = "v=0\r\n\
+                   o=- 0 0 IN IP4 127.0.0.1\r\n\
+                   s=test\r\n\
+                   c=IN IP4 127.0.0.1\r\n\
+                   t=0 0\r\n\
+                   m=video 5004 RTP/AVP 96\r\n\
+                   a=rtpmap:96 H264/90000\r\n\
+                   a=fmtp:96 profile-level-id=42001f;sprop-parameter-sets=Z0IAH5WoFAFuQA==,aM4yyA==\r\n\
+                   m=audio 5006 RTP/AVP 111\r\n\
+                   a=rtpmap:111 opus/48000/2\r\n";
+
+        let source = test_source(sdp);
+        let (ports, media_info, is_ipv6) = source.parse_sdp().unwrap();
+
+        assert_eq!(ports, vec![(0u8, 5004u16), (2u8, 5006u16)]);
+        assert!(!is_ipv6);
+        assert_eq!(media_info.video_rtcp_addr.unwrap().port(), 5005);
+        assert_eq!(media_info.audio_rtcp_addr.unwrap().port(), 5007);
+
+        match media_info.video_codec.unwrap() {
+            rtsp::VideoCodecParams::H264 { sps, pps, .. } => {
+                assert!(!sps.is_empty(), "H264 sprop SPS must be retained");
+                assert!(!pps.is_empty(), "H264 sprop PPS must be retained");
+            }
+            other => panic!("expected H264, got {other:?}"),
+        }
+
+        let audio = media_info.audio_codec.unwrap();
+        assert_eq!(audio.codec.to_lowercase(), "opus");
+        assert_eq!(audio.clock_rate, 48000);
+        assert_eq!(audio.channels, 2);
     }
 }

--- a/livetwo/src/protocol/rtp.rs
+++ b/livetwo/src/protocol/rtp.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Notify;
-use tracing::{debug, info, warn};
+use tracing::{debug, info};
 
 use crate::utils;
 use rtsp::constants::media_type;
@@ -55,53 +55,21 @@ pub async fn setup_rtp_input(target_url: &str) -> Result<(rtsp::MediaInfo, Strin
             .map_err(|e| anyhow!("Invalid IP address in SDP: {}", e))?;
         host = addr.to_string();
     }
-    let video_track = sdp.medias.iter().find(|md| md.media == media_type::VIDEO);
-    let audio_track = sdp.medias.iter().find(|md| md.media == media_type::AUDIO);
-    let (codec_vid, codec_aud) = parse_codecs(&video_track, &audio_track);
+
+    // Shared SDP parsing (libs/rtsp): keeps codec parameters such as H264
+    // sprop-parameter-sets and H265 sprop-vps/sps/pps so the WHIP track setup
+    // can inject them instead of silently dropping parameter sets.
+    let (video_codec, audio_codec) = rtsp::parse_codecs_from_sdp(&sdp)?;
+    let (video_transport, audio_transport) = rtsp::parse_transports_from_sdp(&sdp);
 
     let media_info = rtsp::MediaInfo {
-        video_transport: video_track.map(|track| {
-            let port = track.port;
-            rtsp::TransportInfo::Udp {
-                rtp_send_port: None,
-                rtp_recv_port: Some(port),
-                rtcp_send_port: None,
-                rtcp_recv_port: Some(port + 1),
-                server_addr: None,
-            }
-        }),
-        audio_transport: audio_track.map(|track| {
-            let port = track.port;
-            rtsp::TransportInfo::Udp {
-                rtp_send_port: None,
-                rtp_recv_port: Some(port),
-                rtcp_send_port: None,
-                rtcp_recv_port: Some(port + 1),
-                server_addr: None,
-            }
-        }),
-        video_codec: if !codec_vid.is_empty() && codec_vid != "unknown" {
-            Some(codec_from_str(&codec_vid)?.into())
-        } else {
-            None
-        },
-        audio_codec: if !codec_aud.is_empty() && codec_aud != "unknown" {
-            Some(codec_from_str(&codec_aud)?.into())
-        } else {
-            None
-        },
+        video_transport,
+        audio_transport,
+        video_codec,
+        audio_codec,
     };
 
-    warn!(
-        "SDP parsed: host={}, audio_port={:?}, video_port={:?}, audio_codec={}, video_codec={}, audio_transport={:?}, video_transport={:?}",
-        host,
-        audio_track.map(|t| t.port),
-        video_track.map(|t| t.port),
-        codec_aud,
-        codec_vid,
-        media_info.audio_transport,
-        media_info.video_transport,
-    );
+    info!("SDP parsed: host={}, media_info={:?}", host, media_info);
 
     Ok((media_info, host))
 }
@@ -240,37 +208,6 @@ pub async fn setup_rtp_output(
     debug!("Sent signal to start child process");
 
     Ok(media_info)
-}
-
-fn parse_codecs(
-    video_track: &Option<&sdp_types::Media>,
-    audio_track: &Option<&sdp_types::Media>,
-) -> (String, String) {
-    let codec_vid = video_track
-        .and_then(extract_codec_name)
-        .unwrap_or_else(|| "unknown".to_string());
-
-    let codec_aud = audio_track
-        .and_then(extract_codec_name)
-        .unwrap_or_else(|| "unknown".to_string());
-
-    (codec_vid, codec_aud)
-}
-
-fn extract_codec_name(media: &sdp_types::Media) -> Option<String> {
-    media
-        .attributes
-        .iter()
-        .find(|attr| attr.attribute == "rtpmap")
-        .and_then(|attr| attr.value.as_ref())
-        .and_then(|value| {
-            value
-                .split_whitespace()
-                .nth(1)?
-                .split('/')
-                .next()
-                .map(|s| s.to_string())
-        })
 }
 
 fn extract_codec_from_media(

--- a/src/livetwo.rs
+++ b/src/livetwo.rs
@@ -1,0 +1,16 @@
+//! Unified `livetwo` command: all protocol-conversion tools in one binary.
+//!
+//! Subcommands:
+//! - `livetwo whip`  — publish a stream into a WHIP endpoint (alias: whipinto)
+//! - `livetwo whep`  — pull a stream from a WHEP endpoint (alias: whepfrom)
+//! - `livetwo synth` — publish generated test frames (alias: whipsynth, rsmpeg)
+//! - `livetwo probe` — probe/decode a WHEP endpoint (alias: whepprobe, rsmpeg)
+
+mod livetwo_cli;
+mod log;
+mod utils;
+
+#[tokio::main]
+async fn main() {
+    livetwo_cli::cli_main().await;
+}

--- a/src/livetwo_cli.rs
+++ b/src/livetwo_cli.rs
@@ -1,0 +1,491 @@
+//! Shared CLI implementation for the unified `livetwo` command and the legacy
+//! per-tool alias binaries (`whipinto`, `whepfrom`, `whipsynth`, `whepprobe`).
+//!
+//! All argument parsing and run logic lives here so the unified binary and the
+//! aliases can never drift apart. Legacy flag spellings (`--whip`, `--whep`)
+//! are kept as visible aliases of the unified `--url` spelling.
+
+// Each alias binary uses only the subcommand it wraps; the rest of this shared
+// module is intentionally compiled but unused there.
+#![allow(dead_code)]
+
+#[cfg(feature = "rsmpeg")]
+use std::time::Duration;
+
+use anyhow::Result;
+#[cfg(feature = "rsmpeg")]
+use anyhow::{Context, anyhow};
+#[cfg(feature = "rsmpeg")]
+use clap::ValueEnum;
+use clap::{ArgAction, Args, Parser, Subcommand};
+use tokio_util::sync::CancellationToken;
+use tracing::{Level, info};
+
+use crate::{log, utils};
+
+/// Unified `livetwo` command line: all protocol-conversion tools in one binary.
+#[derive(Parser)]
+#[command(
+    name = "livetwo",
+    version = version::version_with_features!(),
+    about = "WHIP/WHEP <-> RTP/RTSP protocol converter"
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Publish a stream into a WHIP endpoint (formerly whipinto)
+    Whip(WhipArgs),
+    /// Pull a stream from a WHEP endpoint (formerly whepfrom)
+    Whep(WhepArgs),
+    /// Publish in-process generated test frames (formerly whipsynth)
+    #[cfg(feature = "rsmpeg")]
+    Synth(SynthArgs),
+    /// Probe a WHEP endpoint and decode a few frames (formerly whepprobe)
+    #[cfg(feature = "rsmpeg")]
+    Probe(ProbeArgs),
+}
+
+/// Entry point of the unified `livetwo` binary.
+pub async fn cli_main() {
+    let code = match run_cli().await {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("Error: {e:?}");
+            1
+        }
+    };
+    std::process::exit(code);
+}
+
+async fn run_cli() -> Result<i32> {
+    match Cli::parse().command {
+        Commands::Whip(args) => run_whip("livetwo", args).await.map(|_| 0),
+        Commands::Whep(args) => run_whep("livetwo", args).await.map(|_| 0),
+        #[cfg(feature = "rsmpeg")]
+        Commands::Synth(args) => run_synth("livetwo", args).await.map(|_| 0),
+        #[cfg(feature = "rsmpeg")]
+        Commands::Probe(args) => run_probe("livetwo", args)
+            .await
+            .map(|success| i32::from(!success)),
+    }
+}
+
+#[derive(Debug, Args)]
+pub struct WhipArgs {
+    /// Verbose mode [default: "warn", -v "info", -vv "debug", -vvv "trace"]
+    #[arg(short = 'v', action = ArgAction::Count, default_value_t = 0)]
+    verbose: u8,
+    /// rtp://[ip]:[port] / rtsp://[username]:[password]@[ip]:[port]/[stream] / <stream.sdp> / synth://<vcodec>?...
+    #[arg(short, long, default_value_t = format!("{}://0.0.0.0:8554", livetwo::SCHEME_RTP_SDP))]
+    input: String,
+    /// The WHIP server endpoint to POST SDP offer to. e.g.: https://example.com/whip/777
+    #[arg(short = 'w', long = "url", visible_alias = "whip")]
+    url: String,
+    /// Authentication token to use, will be sent in the HTTP Header as 'Bearer '
+    #[arg(short, long)]
+    token: Option<String>,
+    /// Run a command as childprocess
+    #[arg(long)]
+    command: Option<String>,
+}
+
+#[derive(Debug, Args)]
+pub struct WhepArgs {
+    /// Verbose mode [default: "warn", -v "info", -vv "debug", -vvv "trace"]
+    #[arg(short = 'v', action = ArgAction::Count, default_value_t = 0)]
+    verbose: u8,
+    /// rtp://[ip]:[port] / rtsp-listen://[ip]:[port] / rtsp://[username]:[password]@[ip]:[port]/[stream] / <output.sdp>
+    #[arg(short, long, default_value_t = format!("{}://0.0.0.0:8555", livetwo::SCHEME_RTP_SDP))]
+    output: String,
+    /// The WHEP server endpoint to POST SDP offer to. e.g.: https://example.com/whep/777
+    #[arg(short = 'u', long = "url", visible_alias = "whep")]
+    url: String,
+    /// SDP filename to write to (used in RTP mode)
+    #[arg(long, default_value = "output.sdp")]
+    sdp_file: Option<String>,
+    /// Authentication token to use, will be sent in the HTTP Header as 'Bearer '
+    #[arg(short, long)]
+    token: Option<String>,
+    /// Run a command as childprocess
+    #[arg(long)]
+    command: Option<String>,
+    /// Channel URL for DataChannel <-> UDP forwarding
+    /// Format: udp://<listen_host>:<listen_port>?host=<target_host>&port=<target_port>
+    /// Example: udp://0.0.0.0:9001?host=127.0.0.1&port=9000
+    #[arg(long)]
+    channel: Option<String>,
+}
+
+#[cfg(feature = "rsmpeg")]
+#[derive(Debug, Args)]
+pub struct SynthArgs {
+    /// Verbose mode [default: "warn", -v "info", -vv "debug", -vvv "trace"]
+    #[arg(short = 'v', action = ArgAction::Count, default_value_t = 0)]
+    verbose: u8,
+    /// The WHIP server endpoint to POST SDP offer to. e.g.: https://example.com/whip/777
+    #[arg(short = 'w', long = "url", visible_alias = "whip")]
+    url: String,
+    /// Authentication token to use, will be sent in the HTTP Header as 'Bearer '
+    #[arg(short, long)]
+    token: Option<String>,
+    /// Video codec: vp8, vp9, h264, h265, av1
+    #[arg(long = "vcodec", default_value = "vp8")]
+    video_codec: String,
+    /// Audio codec: opus, g722 (omit for no audio)
+    #[arg(long = "acodec")]
+    audio_codec: Option<String>,
+    /// Video width in pixels
+    #[arg(long, default_value_t = 640)]
+    width: u32,
+    /// Video height in pixels
+    #[arg(long, default_value_t = 480)]
+    height: u32,
+    /// Video frame rate
+    #[arg(long, default_value_t = 30)]
+    fps: u32,
+    /// Run for the specified number of seconds, then exit (default: run until interrupted)
+    #[arg(long)]
+    duration: Option<u64>,
+    /// Number of concurrent WHIP sessions to publish (loadtest mode).
+    #[arg(long, default_value_t = 1, hide = true)]
+    count: usize,
+    /// Milliseconds to wait between spawning each loadtest session.
+    #[arg(long, default_value_t = 100, hide = true)]
+    spawn_interval_ms: u64,
+    /// Overall timeout in seconds. If the publisher cannot connect or the
+    /// loadtest cannot finish within this time, exit with an error.
+    #[arg(long, default_value_t = 60)]
+    timeout: u64,
+    /// STUN server URL used for ICE gathering.
+    #[arg(long, default_value = "stun:stun.l.google.com:19302")]
+    stun_server: String,
+}
+
+#[cfg(feature = "rsmpeg")]
+#[derive(Debug, Clone, Copy, ValueEnum)]
+pub enum ProbeOutputFormat {
+    Human,
+    Json,
+}
+
+#[cfg(feature = "rsmpeg")]
+#[derive(Debug, Args)]
+pub struct ProbeArgs {
+    /// Verbose mode [default: "warn", -v "info", -vv "debug", -vvv "trace"]
+    #[arg(short = 'v', action = ArgAction::Count, default_value_t = 0)]
+    verbose: u8,
+    /// WHEP endpoint URL, e.g. http://localhost:7777/whep/live
+    #[arg(short = 'u', long = "url", visible_alias = "whep")]
+    url: String,
+    /// Output format: human, json
+    #[arg(short, long, value_enum, default_value = "human")]
+    output: ProbeOutputFormat,
+    /// Overall timeout in seconds
+    #[arg(long, default_value_t = 30)]
+    timeout: u64,
+    /// Expected video codec: vp8, vp9, h264, h265, av1.
+    /// The rsmpeg backend auto-detects the codec from the WHEP session, so
+    /// this option only affects the reported result.
+    #[arg(long)]
+    codec: Option<String>,
+    /// H265 sprop parameters (`sprop-vps=...;sprop-sps=...;sprop-pps=...`)
+    #[arg(long)]
+    sprop_params: Option<String>,
+    /// How many seconds to decode after the WHEP session connects
+    #[arg(long, default_value_t = 5)]
+    decode_duration: u64,
+    /// Authentication token to use, sent in the HTTP Authorization header as 'Bearer '
+    #[arg(short, long)]
+    token: Option<String>,
+}
+
+fn simple_log_level(verbose: u8) -> Level {
+    match verbose {
+        0 => Level::WARN,
+        1 => Level::INFO,
+        2 => Level::DEBUG,
+        _ => Level::TRACE,
+    }
+}
+
+fn detailed_log_levels(verbose: u8) -> (Level, Level) {
+    match verbose {
+        0 => (Level::WARN, Level::ERROR),
+        1 => (Level::INFO, Level::WARN),
+        2 => (Level::DEBUG, Level::INFO),
+        _ => (Level::TRACE, Level::DEBUG),
+    }
+}
+
+/// Publish a stream into a WHIP endpoint (the former `whipinto` flow).
+pub async fn run_whip(tool: &'static str, args: WhipArgs) -> Result<()> {
+    let log_level = simple_log_level(args.verbose);
+    log::set(format!(
+        "{tool}={},livetwo={},rtsp={},webrtc=error",
+        log_level, log_level, log_level,
+    ));
+
+    let ct = CancellationToken::new();
+    let handle = tokio::spawn(livetwo::whip::into(
+        ct.clone(),
+        args.input.clone(),
+        args.url.clone(),
+        args.token.clone(),
+        args.command.clone(),
+    ));
+
+    utils::shutdown_signal().await;
+    ct.cancel();
+    handle.await??;
+    info!("=== Graceful shutdown completed ===");
+
+    Ok(())
+}
+
+/// Pull a stream from a WHEP endpoint (the former `whepfrom` flow).
+pub async fn run_whep(tool: &'static str, args: WhepArgs) -> Result<()> {
+    let log_level = simple_log_level(args.verbose);
+    log::set(format!(
+        "{tool}={},livetwo={},rtsp={},webrtc=error",
+        log_level, log_level, log_level,
+    ));
+
+    let ct = CancellationToken::new();
+    let handle = tokio::spawn(livetwo::whep::from(
+        ct.clone(),
+        args.output.clone(),
+        args.url.clone(),
+        args.sdp_file.clone(),
+        args.token.clone(),
+        args.command.clone(),
+        args.channel.clone(),
+    ));
+
+    utils::shutdown_signal().await;
+    ct.cancel();
+    handle.await??;
+    info!("=== Graceful shutdown completed ===");
+
+    Ok(())
+}
+
+/// Publish in-process generated test frames (the former `whipsynth` flow).
+#[cfg(feature = "rsmpeg")]
+pub async fn run_synth(tool: &'static str, args: SynthArgs) -> Result<()> {
+    let (log_level, webrtc_level) = detailed_log_levels(args.verbose);
+    log::set(format!(
+        "{tool}={},livetwo={},webrtc={}",
+        log_level, log_level, webrtc_level,
+    ));
+
+    let video_codec_cli = cli::codec_from_str(&args.video_codec)
+        .with_context(|| format!("Invalid video codec: {}", args.video_codec))?;
+    let video_codec = livetwo::source::VideoCodec::from_cli(video_codec_cli)
+        .ok_or_else(|| anyhow!("Unsupported video codec: {}", args.video_codec))?;
+
+    let audio_codec = match &args.audio_codec {
+        Some(name) => {
+            let audio_codec_cli = cli::codec_from_str(name)
+                .with_context(|| format!("Invalid audio codec: {name}"))?;
+            Some(
+                livetwo::source::AudioCodec::from_cli(audio_codec_cli)
+                    .ok_or_else(|| anyhow!("Unsupported audio codec: {name}"))?,
+            )
+        }
+        None => None,
+    };
+
+    let config = livetwo::whipsynth::PublisherConfig {
+        whip_url: args.url.clone(),
+        token: args.token.clone(),
+        video_codec,
+        audio_codec,
+        width: args.width,
+        height: args.height,
+        fps: args.fps,
+        duration: args.duration.map(Duration::from_secs),
+        stun_server: args.stun_server.clone(),
+    };
+
+    info!(
+        whip_url = %args.url,
+        video_codec = %args.video_codec,
+        audio_codec = ?args.audio_codec,
+        width = args.width,
+        height = args.height,
+        fps = args.fps,
+        duration = ?args.duration,
+        count = args.count,
+        spawn_interval_ms = args.spawn_interval_ms,
+        "Starting WHIP synthetic stream generator"
+    );
+
+    let ct = CancellationToken::new();
+    let timeout = Duration::from_secs(args.timeout);
+
+    if args.count > 1 {
+        let loadtest_config = livetwo::whipsynth::LoadtestConfig {
+            publisher_config: config,
+            session_count: args.count,
+            spawn_interval: Duration::from_millis(args.spawn_interval_ms),
+        };
+
+        tokio::select! {
+            result = livetwo::whipsynth::run_loadtest(loadtest_config, ct.clone()) => {
+                let stats = result?;
+                info!(?stats, "Loadtest finished");
+            }
+            _ = tokio::time::sleep(timeout) => {
+                ct.cancel();
+                return Err(anyhow!("loadtest timed out after {:?}", timeout));
+            }
+            _ = utils::shutdown_signal() => {
+                info!("Shutdown signal received, stopping loadtest");
+                ct.cancel();
+            }
+        }
+    } else {
+        let publisher = livetwo::whipsynth::Publisher::new(config);
+
+        if let Some(duration) = args.duration {
+            let run_timeout = Duration::from_secs(duration).saturating_add(timeout);
+            tokio::select! {
+                result = publisher.run(ct.clone()) => {
+                    let _stats = result?;
+                }
+                _ = tokio::time::sleep(run_timeout) => {
+                    ct.cancel();
+                    return Err(anyhow!("publisher timed out after {:?}", run_timeout));
+                }
+                _ = utils::shutdown_signal() => {
+                    info!("Shutdown signal received, stopping publisher");
+                    ct.cancel();
+                }
+            }
+        } else {
+            tokio::select! {
+                result = publisher.run(ct.clone()) => {
+                    let _stats = result?;
+                }
+                _ = utils::shutdown_signal() => {
+                    info!("Shutdown signal received, stopping publisher");
+                    ct.cancel();
+                }
+            }
+        }
+    }
+
+    info!("=== Graceful shutdown completed ===");
+    Ok(())
+}
+
+/// Probe a WHEP endpoint (the former `whepprobe` flow).
+///
+/// Returns `Ok(true)` when the probe succeeded, `Ok(false)` for a completed
+/// but unsuccessful probe, and `Err` for CLI-level failures.
+#[cfg(feature = "rsmpeg")]
+pub async fn run_probe(tool: &'static str, args: ProbeArgs) -> Result<bool> {
+    use livetwo::probe::{ProbeBackend, ProbeConfig, ProbeResult, rsmpeg::RsmpegProbe};
+
+    let (log_level, webrtc_level) = detailed_log_levels(args.verbose);
+    log::set(format!(
+        "{tool}={},livetwo={},webrtc={}",
+        log_level, log_level, webrtc_level,
+    ));
+
+    let codec = match &args.codec {
+        Some(c) => Some(cli::codec_from_str(c).with_context(|| format!("Invalid codec: {c}"))?),
+        None => None,
+    };
+
+    let config = ProbeConfig {
+        whep_url: args.url.clone(),
+        timeout: Duration::from_secs(args.timeout),
+        codec,
+        sprop_params: args.sprop_params.clone(),
+        token: args.token.clone(),
+    };
+
+    info!(
+        whep_url = %config.whep_url,
+        codec = ?config.codec,
+        timeout = ?config.timeout,
+        "Starting WHEP probe (rsmpeg)"
+    );
+
+    let backend = RsmpegProbe {
+        decode_duration: Duration::from_secs(args.decode_duration),
+    };
+
+    let result = tokio::time::timeout(config.timeout, backend.probe(&config)).await;
+
+    match result {
+        Ok(Ok(result)) => {
+            let success = result.success;
+            print_probe_result(&result, args.output);
+            if success {
+                info!("=== Probe succeeded ===");
+            }
+            Ok(success)
+        }
+        Ok(Err(e)) => {
+            // Emit a structured failure result for JSON consumers without
+            // duplicating the diagnostics on stderr.
+            let failed = ProbeResult::failed("rsmpeg", format!("{e:?}"));
+            print_probe_result(&failed, args.output);
+            Ok(false)
+        }
+        Err(_) => {
+            let failed =
+                ProbeResult::failed("rsmpeg", format!("timed out after {:?}", config.timeout));
+            print_probe_result(&failed, args.output);
+            Ok(false)
+        }
+    }
+}
+
+#[cfg(feature = "rsmpeg")]
+fn print_probe_result(result: &livetwo::probe::ProbeResult, format: ProbeOutputFormat) {
+    match format {
+        ProbeOutputFormat::Json => {
+            let json = serde_json::to_string_pretty(result)
+                .expect("ProbeResult should always be serializable");
+            println!("{json}");
+        }
+        ProbeOutputFormat::Human => {
+            println!("=== WHEP Probe Result ===");
+            println!("Backend:        {}", result.backend);
+            println!("Connected:      {}", result.connected);
+            println!("Success:        {}", result.success);
+            if let Some(codec) = &result.codec {
+                println!("Codec:          {}", codec);
+            }
+            if result.width > 0 && result.height > 0 {
+                println!("Resolution:     {}x{}", result.width, result.height);
+            }
+            if result.frame_count > 0 {
+                println!("Frames decoded: {}", result.frame_count);
+            }
+            if result.video_tracks > 0 {
+                println!("Video tracks:   {}", result.video_tracks);
+            }
+            if result.audio_tracks > 0 {
+                println!("Audio tracks:   {}", result.audio_tracks);
+            }
+            if result.video_bytes_received > 0 {
+                println!("Video bytes:    {}", result.video_bytes_received);
+            }
+            if result.audio_bytes_received > 0 {
+                println!("Audio bytes:    {}", result.audio_bytes_received);
+            }
+            println!("Duration:       {} ms", result.duration_ms);
+            if let Some(error) = &result.error {
+                println!("Error:          {}", error);
+            }
+        }
+    }
+}

--- a/src/whepfrom.rs
+++ b/src/whepfrom.rs
@@ -1,70 +1,22 @@
-use anyhow::Result;
-use clap::{ArgAction, Parser};
-use tokio_util::sync::CancellationToken;
-use tracing::{Level, info};
+//! Legacy alias for `livetwo whep`. New deployments should prefer the unified
+//! `livetwo` binary; this thin wrapper keeps existing scripts and packages
+//! working unchanged.
 
+use anyhow::Result;
+use clap::Parser;
+
+mod livetwo_cli;
 mod log;
 mod utils;
 
 #[derive(Parser)]
 #[command(name = "whepfrom", version = version::version_with_features!())]
 struct Args {
-    /// Verbose mode [default: "warn", -v "info", -vv "debug", -vvv "trace"]
-    #[arg(short = 'v', action = ArgAction::Count, default_value_t = 0)]
-    verbose: u8,
-    /// rtp://[ip]:[port] / rtsp://[username]:[password]@[ip]:[port]/[stream] / <stream.sdp>
-    #[arg(short, long, default_value_t = format!("{}://0.0.0.0:8555", livetwo::SCHEME_RTP_SDP))]
-    output: String,
-    /// The WHEP server endpoint to POST SDP offer to. e.g.: https://example.com/whep/777
-    #[arg(short, long)]
-    whep: String,
-    /// SDP filename to write to (used in RTP mode)
-    #[arg(long, default_value = "output.sdp")]
-    sdp_file: Option<String>,
-    /// Authentication token to use, will be sent in the HTTP Header as 'Bearer '
-    #[arg(short, long)]
-    token: Option<String>,
-    /// Run a command as childprocess
-    #[arg(long)]
-    command: Option<String>,
-    /// Channel URL for DataChannel <-> UDP forwarding
-    /// Format: udp://<listen_host>:<listen_port>?host=<target_host>&port=<target_port>
-    /// Example: udp://0.0.0.0:9001?host=127.0.0.1&port=9000
-    #[arg(long)]
-    channel: Option<String>,
+    #[command(flatten)]
+    inner: livetwo_cli::WhepArgs,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args = Args::parse();
-
-    let log_level = match args.verbose {
-        0 => Level::WARN,
-        1 => Level::INFO,
-        2 => Level::DEBUG,
-        _ => Level::TRACE,
-    };
-
-    log::set(format!(
-        "whepfrom={},livetwo={},rtsp={},webrtc=error",
-        log_level, log_level, log_level,
-    ));
-
-    let ct = CancellationToken::new();
-    let handle = tokio::spawn(livetwo::whep::from(
-        ct.clone(),
-        args.output.clone(),
-        args.whep.clone(),
-        args.sdp_file.clone(),
-        args.token.clone(),
-        args.command.clone(),
-        args.channel.clone(),
-    ));
-
-    utils::shutdown_signal().await;
-    ct.cancel();
-    handle.await??;
-    info!("=== Graceful shutdown completed ===");
-
-    Ok(())
+    livetwo_cli::run_whep("whepfrom", Args::parse().inner).await
 }

--- a/src/whepprobe.rs
+++ b/src/whepprobe.rs
@@ -1,60 +1,24 @@
-use std::time::Duration;
+//! Legacy alias for `livetwo probe`. New deployments should prefer the unified
+//! `livetwo` binary; this thin wrapper keeps existing scripts and packages
+//! working unchanged.
 
-use anyhow::{Context, Result};
-use clap::{ArgAction, Parser, ValueEnum};
-use tracing::{Level, info};
+use clap::Parser;
 
+mod livetwo_cli;
 mod log;
-
-use livetwo::probe::{ProbeBackend, ProbeConfig, ProbeResult, rsmpeg::RsmpegProbe};
-
-#[derive(Debug, Clone, Copy, ValueEnum)]
-enum OutputFormat {
-    Human,
-    Json,
-}
+#[allow(dead_code)]
+mod utils;
 
 #[derive(Parser)]
 #[command(name = "whepprobe", version = version::version_with_features!())]
 struct Args {
-    /// Verbose mode [default: "warn", -v "info", -vv "debug", -vvv "trace"]
-    #[arg(short = 'v', action = ArgAction::Count, default_value_t = 0)]
-    verbose: u8,
-
-    /// WHEP endpoint URL, e.g. http://localhost:7777/whep/live
-    #[arg(short, long)]
-    whep: String,
-
-    /// Output format: human, json
-    #[arg(short, long, value_enum, default_value = "human")]
-    output: OutputFormat,
-
-    /// Overall timeout in seconds
-    #[arg(long, default_value_t = 30)]
-    timeout: u64,
-
-    /// Expected video codec: vp8, vp9, h264, h265, av1.
-    /// The rsmpeg backend auto-detects the codec from the WHEP session, so
-    /// this option only affects the reported result.
-    #[arg(long)]
-    codec: Option<String>,
-
-    /// H265 sprop parameters (`sprop-vps=...;sprop-sps=...;sprop-pps=...`)
-    #[arg(long)]
-    sprop_params: Option<String>,
-
-    /// How many seconds to decode after the WHEP session connects
-    #[arg(long, default_value_t = 5)]
-    decode_duration: u64,
-
-    /// Authentication token to use, sent in the HTTP Authorization header as 'Bearer '
-    #[arg(short, long)]
-    token: Option<String>,
+    #[command(flatten)]
+    inner: livetwo_cli::ProbeArgs,
 }
 
 #[tokio::main]
 async fn main() {
-    let code = match run().await {
+    let code = match livetwo_cli::run_probe("whepprobe", Args::parse().inner).await {
         Ok(true) => 0,
         Ok(false) => 1,
         Err(e) => {
@@ -63,115 +27,4 @@ async fn main() {
         }
     };
     std::process::exit(code);
-}
-
-async fn run() -> Result<bool> {
-    let args = Args::parse();
-
-    let (log_level, webrtc_level) = match args.verbose {
-        0 => (Level::WARN, Level::ERROR),
-        1 => (Level::INFO, Level::WARN),
-        2 => (Level::DEBUG, Level::INFO),
-        _ => (Level::TRACE, Level::DEBUG),
-    };
-
-    log::set(format!(
-        "whepprobe={},livetwo={},webrtc={}",
-        log_level, log_level, webrtc_level,
-    ));
-
-    let config = build_config(&args)?;
-
-    info!(
-        whep_url = %config.whep_url,
-        codec = ?config.codec,
-        timeout = ?config.timeout,
-        "Starting WHEP probe (rsmpeg)"
-    );
-
-    let backend = RsmpegProbe {
-        decode_duration: Duration::from_secs(args.decode_duration),
-    };
-
-    let result = tokio::time::timeout(config.timeout, backend.probe(&config)).await;
-
-    match result {
-        Ok(Ok(result)) => {
-            let success = result.success;
-            print_result(&result, args.output);
-            if success {
-                info!("=== Probe succeeded ===");
-            }
-            Ok(success)
-        }
-        Ok(Err(e)) => {
-            // Emit a structured failure result for JSON consumers without
-            // duplicating the diagnostics on stderr.
-            let failed = ProbeResult::failed("rsmpeg", format!("{e:?}"));
-            print_result(&failed, args.output);
-            Ok(false)
-        }
-        Err(_) => {
-            let failed =
-                ProbeResult::failed("rsmpeg", format!("timed out after {:?}", config.timeout));
-            print_result(&failed, args.output);
-            Ok(false)
-        }
-    }
-}
-
-fn build_config(args: &Args) -> Result<ProbeConfig> {
-    let codec = match &args.codec {
-        Some(c) => Some(cli::codec_from_str(c).with_context(|| format!("Invalid codec: {c}"))?),
-        None => None,
-    };
-
-    Ok(ProbeConfig {
-        whep_url: args.whep.clone(),
-        timeout: Duration::from_secs(args.timeout),
-        codec,
-        sprop_params: args.sprop_params.clone(),
-        token: args.token.clone(),
-    })
-}
-
-fn print_result(result: &ProbeResult, format: OutputFormat) {
-    match format {
-        OutputFormat::Json => {
-            let json = serde_json::to_string_pretty(result)
-                .expect("ProbeResult should always be serializable");
-            println!("{json}");
-        }
-        OutputFormat::Human => {
-            println!("=== WHEP Probe Result ===");
-            println!("Backend:        {}", result.backend);
-            println!("Connected:      {}", result.connected);
-            println!("Success:        {}", result.success);
-            if let Some(codec) = &result.codec {
-                println!("Codec:          {}", codec);
-            }
-            if result.width > 0 && result.height > 0 {
-                println!("Resolution:     {}x{}", result.width, result.height);
-            }
-            if result.frame_count > 0 {
-                println!("Frames decoded: {}", result.frame_count);
-            }
-            if result.video_tracks > 0 {
-                println!("Video tracks:   {}", result.video_tracks);
-            }
-            if result.audio_tracks > 0 {
-                println!("Audio tracks:   {}", result.audio_tracks);
-            }
-            if result.video_bytes_received > 0 {
-                println!("Video bytes:    {}", result.video_bytes_received);
-            }
-            if result.audio_bytes_received > 0 {
-                println!("Audio bytes:    {}", result.audio_bytes_received);
-            }
-            println!("Duration:       {} ms", result.duration_ms);
-            if let Some(error) = &result.error {
-                println!("Error:          {}", error);
-            }
-        }
-    }
 }

--- a/src/whipinto.rs
+++ b/src/whipinto.rs
@@ -1,60 +1,22 @@
-use anyhow::Result;
-use clap::{ArgAction, Parser};
-use tokio_util::sync::CancellationToken;
-use tracing::{Level, info};
+//! Legacy alias for `livetwo whip`. New deployments should prefer the unified
+//! `livetwo` binary; this thin wrapper keeps existing scripts and packages
+//! working unchanged.
 
+use anyhow::Result;
+use clap::Parser;
+
+mod livetwo_cli;
 mod log;
 mod utils;
 
 #[derive(Parser)]
 #[command(name = "whipinto", version = version::version_with_features!())]
 struct Args {
-    /// Verbose mode [default: "warn", -v "info", -vv "debug", -vvv "trace"]
-    #[arg(short = 'v', action = ArgAction::Count, default_value_t = 0)]
-    verbose: u8,
-    /// rtp://[ip]:[port] / rtsp://[username]:[password]@[ip]:[port]/[stream] / <stream.sdp>
-    #[arg(short, long, default_value_t = format!("{}://0.0.0.0:8554", livetwo::SCHEME_RTP_SDP))]
-    input: String,
-    /// The WHIP server endpoint to POST SDP offer to. e.g.: https://example.com/whip/777
-    #[arg(short, long)]
-    whip: String,
-    /// Authentication token to use, will be sent in the HTTP Header as 'Bearer '
-    #[arg(short, long)]
-    token: Option<String>,
-    /// Run a command as childprocess
-    #[arg(long)]
-    command: Option<String>,
+    #[command(flatten)]
+    inner: livetwo_cli::WhipArgs,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let args = Args::parse();
-
-    let log_level = match args.verbose {
-        0 => Level::WARN,
-        1 => Level::INFO,
-        2 => Level::DEBUG,
-        _ => Level::TRACE,
-    };
-
-    log::set(format!(
-        "whipinto={},livetwo={},rtsp={},webrtc=error",
-        log_level, log_level, log_level,
-    ));
-
-    let ct = CancellationToken::new();
-    let handle = tokio::spawn(livetwo::whip::into(
-        ct.clone(),
-        args.input.clone(),
-        args.whip.clone(),
-        args.token.clone(),
-        args.command.clone(),
-    ));
-
-    utils::shutdown_signal().await;
-    ct.cancel();
-    handle.await??;
-    info!("=== Graceful shutdown completed ===");
-
-    Ok(())
+    livetwo_cli::run_whip("whipinto", Args::parse().inner).await
 }

--- a/src/whipsynth.rs
+++ b/src/whipsynth.rs
@@ -1,191 +1,26 @@
-use std::time::Duration;
+//! Legacy alias for `livetwo synth`. New deployments should prefer the unified
+//! `livetwo` binary; this thin wrapper keeps existing scripts and packages
+//! working unchanged.
 
-use anyhow::{Context, Result, anyhow};
-use clap::{ArgAction, Parser};
-use tokio_util::sync::CancellationToken;
-use tracing::{Level, info};
+use anyhow::Result;
+use clap::Parser;
 
+mod livetwo_cli;
 mod log;
 mod utils;
 
 #[derive(Parser)]
 #[command(name = "whipsynth", version = version::version_with_features!())]
 struct Args {
-    /// Verbose mode [default: "warn", -v "info", -vv "debug", -vvv "trace"]
-    #[arg(short = 'v', action = ArgAction::Count, default_value_t = 0)]
-    verbose: u8,
-
-    /// The WHIP server endpoint to POST SDP offer to. e.g.: https://example.com/whip/777
-    #[arg(short, long)]
-    whip: String,
-
-    /// Authentication token to use, will be sent in the HTTP Header as 'Bearer '
-    #[arg(short, long)]
-    token: Option<String>,
-
-    /// Video codec: vp8, vp9, h264, h265, av1
-    #[arg(long = "vcodec", default_value = "vp8")]
-    video_codec: String,
-
-    /// Audio codec: opus, g722 (omit for no audio)
-    #[arg(long = "acodec")]
-    audio_codec: Option<String>,
-
-    /// Video width in pixels
-    #[arg(long, default_value_t = 640)]
-    width: u32,
-
-    /// Video height in pixels
-    #[arg(long, default_value_t = 480)]
-    height: u32,
-
-    /// Video frame rate
-    #[arg(long, default_value_t = 30)]
-    fps: u32,
-
-    /// Run for the specified number of seconds, then exit (default: run until interrupted)
-    #[arg(long)]
-    duration: Option<u64>,
-
-    /// Number of concurrent WHIP sessions to publish (loadtest mode).
-    #[arg(long, default_value_t = 1, hide = true)]
-    count: usize,
-
-    /// Milliseconds to wait between spawning each loadtest session.
-    #[arg(long, default_value_t = 100, hide = true)]
-    spawn_interval_ms: u64,
-
-    /// Overall timeout in seconds. If the publisher cannot connect or the
-    /// loadtest cannot finish within this time, exit with an error.
-    #[arg(long, default_value_t = 60)]
-    timeout: u64,
-
-    /// STUN server URL used for ICE gathering.
-    #[arg(long, default_value = "stun:stun.l.google.com:19302")]
-    stun_server: String,
+    #[command(flatten)]
+    inner: livetwo_cli::SynthArgs,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    if let Err(e) = run().await {
+    if let Err(e) = livetwo_cli::run_synth("whipsynth", Args::parse().inner).await {
         eprintln!("Error: {e:?}");
         std::process::exit(1);
     }
-    Ok(())
-}
-
-async fn run() -> Result<()> {
-    let args = Args::parse();
-
-    let (log_level, webrtc_level) = match args.verbose {
-        0 => (Level::WARN, Level::ERROR),
-        1 => (Level::INFO, Level::WARN),
-        2 => (Level::DEBUG, Level::INFO),
-        _ => (Level::TRACE, Level::DEBUG),
-    };
-
-    log::set(format!(
-        "whipsynth={},livetwo={},webrtc={}",
-        log_level, log_level, webrtc_level,
-    ));
-
-    let video_codec_cli = cli::codec_from_str(&args.video_codec)
-        .with_context(|| format!("Invalid video codec: {}", args.video_codec))?;
-    let video_codec = livetwo::source::VideoCodec::from_cli(video_codec_cli)
-        .ok_or_else(|| anyhow!("Unsupported video codec: {}", args.video_codec))?;
-
-    let audio_codec = match &args.audio_codec {
-        Some(name) => {
-            let audio_codec_cli = cli::codec_from_str(name)
-                .with_context(|| format!("Invalid audio codec: {}", name))?;
-            Some(
-                livetwo::source::AudioCodec::from_cli(audio_codec_cli)
-                    .ok_or_else(|| anyhow!("Unsupported audio codec: {}", name))?,
-            )
-        }
-        None => None,
-    };
-
-    let config = livetwo::whipsynth::PublisherConfig {
-        whip_url: args.whip.clone(),
-        token: args.token.clone(),
-        video_codec,
-        audio_codec,
-        width: args.width,
-        height: args.height,
-        fps: args.fps,
-        duration: args.duration.map(Duration::from_secs),
-        stun_server: args.stun_server.clone(),
-    };
-
-    info!(
-        whip_url = %args.whip,
-        video_codec = %args.video_codec,
-        audio_codec = ?args.audio_codec,
-        width = args.width,
-        height = args.height,
-        fps = args.fps,
-        duration = ?args.duration,
-        count = args.count,
-        spawn_interval_ms = args.spawn_interval_ms,
-        "Starting WHIP synthetic stream generator"
-    );
-
-    let ct = CancellationToken::new();
-    let timeout = Duration::from_secs(args.timeout);
-
-    if args.count > 1 {
-        let loadtest_config = livetwo::whipsynth::LoadtestConfig {
-            publisher_config: config,
-            session_count: args.count,
-            spawn_interval: Duration::from_millis(args.spawn_interval_ms),
-        };
-
-        tokio::select! {
-            result = livetwo::whipsynth::run_loadtest(loadtest_config, ct.clone()) => {
-                let stats = result?;
-                info!(?stats, "Loadtest finished");
-            }
-            _ = tokio::time::sleep(timeout) => {
-                ct.cancel();
-                return Err(anyhow!("loadtest timed out after {:?}", timeout));
-            }
-            _ = utils::shutdown_signal() => {
-                info!("Shutdown signal received, stopping loadtest");
-                ct.cancel();
-            }
-        }
-    } else {
-        let publisher = livetwo::whipsynth::Publisher::new(config);
-
-        if let Some(duration) = args.duration {
-            let run_timeout = Duration::from_secs(duration).saturating_add(timeout);
-            tokio::select! {
-                result = publisher.run(ct.clone()) => {
-                    let _stats = result?;
-                }
-                _ = tokio::time::sleep(run_timeout) => {
-                    ct.cancel();
-                    return Err(anyhow!("publisher timed out after {:?}", run_timeout));
-                }
-                _ = utils::shutdown_signal() => {
-                    info!("Shutdown signal received, stopping publisher");
-                    ct.cancel();
-                }
-            }
-        } else {
-            tokio::select! {
-                result = publisher.run(ct.clone()) => {
-                    let _stats = result?;
-                }
-                _ = utils::shutdown_signal() => {
-                    info!("Shutdown signal received, stopping publisher");
-                    ct.cancel();
-                }
-            }
-        }
-    }
-
-    info!("=== Graceful shutdown completed ===");
     Ok(())
 }


### PR DESCRIPTION
## Summary

All protocol-conversion tools now live in a single `livetwo` binary with subcommands mirroring the conversion direction:

```
livetwo whip  --input ... --url ...   (formerly whipinto)
livetwo whep  --output ... --url ...  (formerly whepfrom)
livetwo synth --url ...               (formerly whipsynth, rsmpeg)
livetwo probe --url ...               (formerly whepprobe, rsmpeg)
```

- Argument parsing and run logic are shared in `src/livetwo_cli.rs` so the unified binary and the legacy per-tool aliases can never drift apart
- `whipinto`/`whepfrom`/`whipsynth`/`whepprobe` become thin aliases; `-w/--whip` and `-u/--whep` remain as visible aliases of the unified `--url` spelling, so existing scripts and packages keep working
- The rsmpeg-gated synth/probe subcommands stay out of default (pure-Rust converter) builds
- Release artifacts (docker/nfpm) are unchanged in this PR

Stacked on #383 (M0a).

## Test plan

- [x] builds clean with and without rsmpeg, zero warnings
- [x] end-to-end smoke against a local live777: `livetwo whip` synth publish, `livetwo probe` decode (49 frames), legacy `whipinto --whip` / `whepprobe --whep` spellings
- [x] classic RTP path stable for 60s+ through the unified publish core
- [x] livetwo unit 52/52, integration `tests` 7/7
- [x] CI green