### PR TITLE
chore(livetwo): drop unused md-5 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2863,7 +2863,6 @@ dependencies = [
  "bytes",
  "cli",
  "libwish",
- "md-5",
  "portpicker",
  "rand 0.10.2",
  "rsmpeg",

--- a/livetwo/Cargo.toml
+++ b/livetwo/Cargo.toml
@@ -30,7 +30,6 @@ tempfile = { workspace = true }
 
 bytes = "1.6.0"
 scopeguard = "1.2.0"
-md-5 = "0.10"
 portpicker = "0.1.1"
 sdp-types = "0.1"
 rand = "0.10"


### PR DESCRIPTION
## Summary

- Remove the direct `md-5` dependency from `livetwo` — nothing in `livetwo/src` uses it; it is a leftover from moving the RTSP code into `libs/rtsp` (same cleanup as 979aacf did for `liveion`).
- Keep `md-5` in `libs/rtsp`: `libs/rtsp/src/auth.rs` uses it for RTSP Digest authentication, where MD5 is the protocol-mandated baseline algorithm (RFC 2617/7616), so it cannot be dropped or swapped for another hash without breaking interop with live555 / GStreamer / cameras.

Regarding the upgrade asked for in the issue: `md-5` has no 0.11 — `0.10.6` is the latest release and is already what `Cargo.lock` pins, so there is nothing to upgrade to.

Closes #349

## Test plan

- [x] `cargo check -p livetwo` passes
- [x] `Cargo.lock` no longer lists `md-5` under `livetwo`; `rtsp` keeps its `md-5` edge