### PR TITLE
feat(liveion): stream lifecycle hook scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,15 +202,15 @@ Important config sections: `http`, `stream`, `webrtc`, `ice_servers`, `auth`,
 - `liveion/src/forward/` — SFU forwarding core (publish, subscribe, channel,
   track, bridge, media, RTCP).
 - `liveion/src/stream/` — stream manager + source adapters.
-- `liveion/src/event.rs` — typed stream-lifecycle events (`stream_up` …
-  `subscribe_down` with reasons) on a single manager-wide broadcast bus.
+- `liveion/src/event.rs` — typed stream-lifecycle events (`stream_created` …
+  `subscribe_stopped` with reasons) on a single manager-wide broadcast bus.
   Consumers must tolerate `broadcast::RecvError::Lagged` by continuing the
   loop (and re-snapshotting where applicable).
 - `liveion/src/recorder/` — recording pipeline (fmp4, segmenter, uploader,
   codec-specific writers).
 - `liveion/src/hook.rs` — stream-lifecycle hook scripts (`[hooks]` global +
   `[stream.<name>.hooks]` per stream) run by a single FIFO executor:
-  dispatcher forwards `StreamUp`/`StreamDown` into an internal queue, then
+  dispatcher forwards `StreamCreated`/`StreamDeleted` into an internal queue, then
   scripts run sequentially (global first, per-stream after, configured
   order) with per-script timeout and `on_error` policy.
 - `liveman/src/route/` — proxy/cascade/admin routes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,11 @@ Important config sections: `http`, `stream`, `webrtc`, `ice_servers`, `auth`,
   loop (and re-snapshotting where applicable).
 - `liveion/src/recorder/` — recording pipeline (fmp4, segmenter, uploader,
   codec-specific writers).
+- `liveion/src/hook.rs` — stream-lifecycle hook scripts (`[hooks]` global +
+  `[stream.<name>.hooks]` per stream) run by a single FIFO executor:
+  dispatcher forwards `StreamUp`/`StreamDown` into an internal queue, then
+  scripts run sequentially (global first, per-stream after, configured
+  order) with per-script timeout and `on_error` policy.
 - `liveman/src/route/` — proxy/cascade/admin routes.
 - `liveman/src/service/` — business logic (database, recordings index).
 - `liveman/src/entity/` + `migration/` — Sea-ORM entities and migrations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Webhook-style push notifications are replaced by Server-Sent Events (`GET /api/sse/streams`) and the `net4mqtt` xdata channel, both of which push full stream-state snapshots when the state changes.
   - The `/api/sse/events` endpoint has been removed. Use `/api/sse/streams` instead.
 
+### Added
+
+- `liveion` stream-lifecycle hooks: the new `[hooks]` section (global) and `[stream.<name>.hooks]` (per stream) run external scripts when a stream is created (`StreamCreated`) or deleted (`StreamDeleted`) — e.g. to start a capture device / hardware encoder when an on-demand (`auto_create_whep`) stream appears and stop it on teardown. Scripts receive `<event> <stream> [reason]` as argv and the same values as `LIVE777_EVENT`/`LIVE777_STREAM`/`LIVE777_REASON`; execution is a single FIFO queue (global hooks first, then per-stream, in configured order) with per-script `timeout_ms` and an `on_error = "stop"|"continue"` policy.
+
 ### Changed
 
-- `liveion` stream lifecycle events are now typed (`liveion::event::Event`) and travel on a single manager-wide broadcast bus: `StreamDown` emission is centralized into one funnel so it always pairs with its metrics update, and every consumer (SSE, net4mqtt, recorder) tolerates broadcast lag by re-syncing instead of silently stopping.
+- `liveion` stream lifecycle events are now typed (`liveion::event::Event`) and travel on a single manager-wide broadcast bus: `StreamDeleted` emission is centralized into one funnel so it always pairs with its metrics update, and every consumer (SSE, net4mqtt, recorder) tolerates broadcast lag by re-syncing instead of silently stopping.
 - `liveion` subscribe-side RTP write errors are now retried with a 3s bound while the peer may still be coming up, instead of being classified by matching `webrtc` crate error strings.
 - `liveion` now exposes a single SSE endpoint `/api/sse/streams` that pushes a full snapshot of all streams whenever stream state changes.
 - `net4mqtt` xdata messages now carry the sender identity as part of the channel tuple `(sender_id, key, payload)`. The receiver no longer needs to trust a user-supplied `alias` field inside the payload.

--- a/conf/live777.toml
+++ b/conf/live777.toml
@@ -211,6 +211,23 @@ root = "./storage"
 # auto_create_whip = false
 # auto_create_whep = false
 
+# Stream-lifecycle hooks: run scripts when streams are created/destroyed.
+# Scripts receive `<event> <stream> [reason]` as argv and the same values as
+# LIVE777_EVENT / LIVE777_STREAM / LIVE777_REASON. Hooks of one event run in
+# order (global first, then per-stream); events are processed strictly FIFO.
+# [hooks]
+# Per-script timeout in milliseconds (0 disables)
+# timeout_ms = 5000
+# "stop": skip the remaining hooks of the same event on failure
+# on_error = "stop"
+# on_stream_up = ["/etc/live777/hooks/up.sh"]
+# on_stream_down = ["/etc/live777/hooks/down.sh"]
+
+# Per-stream hooks run after the global [hooks] ones.
+# [stream.cam1.hooks]
+# on_stream_up = ["/etc/live777/hooks/cam1-up.sh"]
+# on_stream_down = ["/etc/live777/hooks/cam1-down.sh"]
+
 # Default enabled `--features=net4mqtt`
 # [net4mqtt]
 # Global unique alias

--- a/conf/live777.toml
+++ b/conf/live777.toml
@@ -211,7 +211,7 @@ root = "./storage"
 # auto_create_whip = false
 # auto_create_whep = false
 
-# Stream-lifecycle hooks: run scripts when streams are created/destroyed.
+# Stream-lifecycle hooks: run scripts when streams are created/deleted.
 # Scripts receive `<event> <stream> [reason]` as argv and the same values as
 # LIVE777_EVENT / LIVE777_STREAM / LIVE777_REASON. Hooks of one event run in
 # order (global first, then per-stream); events are processed strictly FIFO.
@@ -220,13 +220,13 @@ root = "./storage"
 # timeout_ms = 5000
 # "stop": skip the remaining hooks of the same event on failure
 # on_error = "stop"
-# on_stream_up = ["/etc/live777/hooks/up.sh"]
-# on_stream_down = ["/etc/live777/hooks/down.sh"]
+# on_stream_created = ["/etc/live777/hooks/up.sh"]
+# on_stream_deleted = ["/etc/live777/hooks/down.sh"]
 
 # Per-stream hooks run after the global [hooks] ones.
 # [stream.cam1.hooks]
-# on_stream_up = ["/etc/live777/hooks/cam1-up.sh"]
-# on_stream_down = ["/etc/live777/hooks/cam1-down.sh"]
+# on_stream_created = ["/etc/live777/hooks/cam1-up.sh"]
+# on_stream_deleted = ["/etc/live777/hooks/cam1-down.sh"]
 
 # Default enabled `--features=net4mqtt`
 # [net4mqtt]

--- a/conf/live777.toml
+++ b/conf/live777.toml
@@ -220,13 +220,13 @@ root = "./storage"
 # timeout_ms = 5000
 # "stop": skip the remaining hooks of the same event on failure
 # on_error = "stop"
-# on_stream_created = ["/etc/live777/hooks/up.sh"]
-# on_stream_deleted = ["/etc/live777/hooks/down.sh"]
+# on_stream_created = ["/etc/live777/hooks/created.sh"]
+# on_stream_deleted = ["/etc/live777/hooks/deleted.sh"]
 
 # Per-stream hooks run after the global [hooks] ones.
 # [stream.cam1.hooks]
-# on_stream_created = ["/etc/live777/hooks/cam1-up.sh"]
-# on_stream_deleted = ["/etc/live777/hooks/cam1-down.sh"]
+# on_stream_created = ["/etc/live777/hooks/cam1-created.sh"]
+# on_stream_deleted = ["/etc/live777/hooks/cam1-deleted.sh"]
 
 # Default enabled `--features=net4mqtt`
 # [net4mqtt]

--- a/docs/guide/live777.md
+++ b/docs/guide/live777.md
@@ -140,12 +140,12 @@ the stream is torn down, the hook stops it again to save resources.
 timeout_ms = 5000    # per-script timeout, 0 disables
 on_error = "stop"    # "stop" skips the remaining hooks of the same event;
                      # "continue" runs them anyway
-on_stream_created   = ["/etc/live777/hooks/notify.sh"]
+on_stream_created = ["/etc/live777/hooks/notify.sh"]
 on_stream_deleted = ["/etc/live777/hooks/notify.sh", "/etc/live777/hooks/cleanup.sh"]
 
 # Per-stream hooks, run after the global ones.
 [stream.cam1.hooks]
-on_stream_created   = ["/etc/live777/hooks/cam1-created.sh"]
+on_stream_created = ["/etc/live777/hooks/cam1-created.sh"]
 on_stream_deleted = ["/etc/live777/hooks/cam1-deleted.sh"]
 ```
 

--- a/docs/guide/live777.md
+++ b/docs/guide/live777.md
@@ -145,8 +145,8 @@ on_stream_deleted = ["/etc/live777/hooks/notify.sh", "/etc/live777/hooks/cleanup
 
 # Per-stream hooks, run after the global ones.
 [stream.cam1.hooks]
-on_stream_created   = ["/etc/live777/hooks/cam1-up.sh"]
-on_stream_deleted = ["/etc/live777/hooks/cam1-down.sh"]
+on_stream_created   = ["/etc/live777/hooks/cam1-created.sh"]
+on_stream_deleted = ["/etc/live777/hooks/cam1-deleted.sh"]
 ```
 
 Execution guarantees:

--- a/docs/guide/live777.md
+++ b/docs/guide/live777.md
@@ -129,7 +129,7 @@ segment is used as the liveion stream identifier.
 
 ## Stream Hooks
 
-Live777 can run external scripts when streams are created or destroyed. A
+Live777 can run external scripts when streams are created or deleted. A
 typical use is on-demand source activation: when a WHEP subscriber triggers
 `auto_create_whep`, a hook starts a capture device / hardware encoder; when
 the stream is torn down, the hook stops it again to save resources.
@@ -140,13 +140,13 @@ the stream is torn down, the hook stops it again to save resources.
 timeout_ms = 5000    # per-script timeout, 0 disables
 on_error = "stop"    # "stop" skips the remaining hooks of the same event;
                      # "continue" runs them anyway
-on_stream_up   = ["/etc/live777/hooks/notify.sh"]
-on_stream_down = ["/etc/live777/hooks/notify.sh", "/etc/live777/hooks/cleanup.sh"]
+on_stream_created   = ["/etc/live777/hooks/notify.sh"]
+on_stream_deleted = ["/etc/live777/hooks/notify.sh", "/etc/live777/hooks/cleanup.sh"]
 
 # Per-stream hooks, run after the global ones.
 [stream.cam1.hooks]
-on_stream_up   = ["/etc/live777/hooks/cam1-up.sh"]
-on_stream_down = ["/etc/live777/hooks/cam1-down.sh"]
+on_stream_created   = ["/etc/live777/hooks/cam1-up.sh"]
+on_stream_deleted = ["/etc/live777/hooks/cam1-down.sh"]
 ```
 
 Execution guarantees:
@@ -155,7 +155,7 @@ Execution guarantees:
   configured order.
 - Events are processed in a single FIFO queue — all hooks of an earlier
   event finish before any hook of a later event starts, so a stream's
-  `stream-up` hooks always complete before its `stream-down` hooks begin.
+  `stream-created` hooks always complete before its `stream-deleted` hooks begin.
 - A failed script (non-zero exit, spawn error, timeout kill) is logged and
   handled per `on_error`; it never affects later events or the server.
 
@@ -164,21 +164,21 @@ as argv and as environment variables:
 
 | argv          | env               | value                                                                            |
 | ------------- | ----------------- | -------------------------------------------------------------------------------- |
-| `$1`          | `LIVE777_EVENT`   | `stream-up` / `stream-down`                                                      |
+| `$1`          | `LIVE777_EVENT`   | `stream-created` / `stream-deleted`                                                      |
 | `$2`          | `LIVE777_STREAM`  | stream name                                                                      |
-| `$3` (down only) | `LIVE777_REASON` | `api-deleted` / `publish-leave-timeout` / `subscribe-leave-timeout` / `orphaned` |
+| `$3` (deleted only) | `LIVE777_REASON` | `api-deleted` / `publish-leave-timeout` / `subscribe-leave-timeout` / `orphaned` |
 
 Notes:
 
 - Scripts should return quickly after initiating their work (e.g. launch an
   encoder in the background). A blocked script blocks the whole hook queue.
-- Make scripts idempotent: a `stream-down` hook also runs when the publisher
+- Make scripts idempotent: a `stream-deleted` hook also runs when the publisher
   itself died (`publish-leave-timeout`), so stop scripts must tolerate an
   already-stopped device.
 - For on-demand sources, combine with `[strategy] auto_create_whep = true`
   and a generous `auto_delete_whep` (e.g. `30000`) so brief subscriber
   flapping does not cycle the hardware. Per-stream overrides live under
   `[stream.<name>.strategy]`.
-- No hooks fire on server shutdown (no `stream-down` events are emitted
+- No hooks fire on server shutdown (no `stream-deleted` events are emitted
   then).
 

--- a/docs/guide/live777.md
+++ b/docs/guide/live777.md
@@ -127,3 +127,58 @@ The same port handles both directions:
 Both UDP and TCP (`RTP/AVP/TCP`) transports are supported.  The first URL path
 segment is used as the liveion stream identifier.
 
+## Stream Hooks
+
+Live777 can run external scripts when streams are created or destroyed. A
+typical use is on-demand source activation: when a WHEP subscriber triggers
+`auto_create_whep`, a hook starts a capture device / hardware encoder; when
+the stream is torn down, the hook stops it again to save resources.
+
+```toml
+# Global hooks, run for every stream.
+[hooks]
+timeout_ms = 5000    # per-script timeout, 0 disables
+on_error = "stop"    # "stop" skips the remaining hooks of the same event;
+                     # "continue" runs them anyway
+on_stream_up   = ["/etc/live777/hooks/notify.sh"]
+on_stream_down = ["/etc/live777/hooks/notify.sh", "/etc/live777/hooks/cleanup.sh"]
+
+# Per-stream hooks, run after the global ones.
+[stream.cam1.hooks]
+on_stream_up   = ["/etc/live777/hooks/cam1-up.sh"]
+on_stream_down = ["/etc/live777/hooks/cam1-down.sh"]
+```
+
+Execution guarantees:
+
+- Hooks of one event run sequentially: global first, then per-stream, in
+  configured order.
+- Events are processed in a single FIFO queue — all hooks of an earlier
+  event finish before any hook of a later event starts, so a stream's
+  `stream-up` hooks always complete before its `stream-down` hooks begin.
+- A failed script (non-zero exit, spawn error, timeout kill) is logged and
+  handled per `on_error`; it never affects later events or the server.
+
+Scripts are executed directly (no shell) and receive the event metadata both
+as argv and as environment variables:
+
+| argv          | env               | value                                                                            |
+| ------------- | ----------------- | -------------------------------------------------------------------------------- |
+| `$1`          | `LIVE777_EVENT`   | `stream-up` / `stream-down`                                                      |
+| `$2`          | `LIVE777_STREAM`  | stream name                                                                      |
+| `$3` (down only) | `LIVE777_REASON` | `api-deleted` / `publish-leave-timeout` / `subscribe-leave-timeout` / `orphaned` |
+
+Notes:
+
+- Scripts should return quickly after initiating their work (e.g. launch an
+  encoder in the background). A blocked script blocks the whole hook queue.
+- Make scripts idempotent: a `stream-down` hook also runs when the publisher
+  itself died (`publish-leave-timeout`), so stop scripts must tolerate an
+  already-stopped device.
+- For on-demand sources, combine with `[strategy] auto_create_whep = true`
+  and a generous `auto_delete_whep` (e.g. `30000`) so brief subscriber
+  flapping does not cycle the hardware. Per-stream overrides live under
+  `[stream.<name>.strategy]`.
+- No hooks fire on server shutdown (no `stream-down` events are emitted
+  then).
+

--- a/docs/zh/guide/live777.md
+++ b/docs/zh/guide/live777.md
@@ -124,3 +124,53 @@ listen = "0.0.0.0:8554"
 - 拉流地址：`rtsp://host:8554/{stream_id}`（`DESCRIBE` + `PLAY`）
 
 同时支持 UDP 和 TCP（`RTP/AVP/TCP`）传输。URL 的第一段路径作为 liveion 的流标识符。
+
+## 流钩子（Stream Hooks）
+
+Live777 可以在流创建或销毁时执行外部脚本。典型用途是按需激活源：当 WHEP
+观众触发 `auto_create_whep` 建流时，hook 启动采集设备 / 硬件编码器；流销
+毁时，hook 再把它关掉以节省资源。
+
+```toml
+# 全局 hook，对所有流生效
+[hooks]
+timeout_ms = 5000    # 单个脚本超时（毫秒），0 表示不限制
+on_error = "stop"    # "stop"：脚本失败后跳过本事件剩余 hook；
+                     # "continue"：失败后仍继续执行
+on_stream_up   = ["/etc/live777/hooks/notify.sh"]
+on_stream_down = ["/etc/live777/hooks/notify.sh", "/etc/live777/hooks/cleanup.sh"]
+
+# 每流 hook，在全局 hook 之后执行
+[stream.cam1.hooks]
+on_stream_up   = ["/etc/live777/hooks/cam1-up.sh"]
+on_stream_down = ["/etc/live777/hooks/cam1-down.sh"]
+```
+
+执行保证：
+
+- 同一事件的 hook 按顺序串行执行：先全局、后每流，各自按配置顺序。
+- 所有事件共用一个 FIFO 队列处理——前一事件的全部 hook 执行完毕后，后
+  一事件的第一个 hook 才开始，因此同一条流的 `stream-up` hook 一定先于
+  它的 `stream-down` hook 执行完。
+- 脚本失败（非零退出、启动失败、超时被杀）只会被记录并按 `on_error` 处
+  理，不会影响后续事件，也不会影响服务器本身。
+
+脚本以直接执行方式启动（不经过 shell），事件元数据同时通过 argv 和环境
+变量传入：
+
+| argv          | 环境变量          | 取值                                                                               |
+| ------------- | ----------------- | ---------------------------------------------------------------------------------- |
+| `$1`          | `LIVE777_EVENT`   | `stream-up` / `stream-down`                                                        |
+| `$2`          | `LIVE777_STREAM`  | 流名                                                                               |
+| `$3`（仅 down）| `LIVE777_REASON`  | `api-deleted` / `publish-leave-timeout` / `subscribe-leave-timeout` / `orphaned`   |
+
+注意事项：
+
+- 脚本应在发起工作后尽快返回（例如把编码器放到后台启动）。脚本阻塞多久，
+  整个 hook 队列就阻塞多久。
+- 脚本要幂等：推流端自身死亡（`publish-leave-timeout`）也会触发
+  `stream-down` hook，停止脚本必须能容忍设备已经停止的状态。
+- 做按需源时，配合 `[strategy] auto_create_whep = true` 和较大的
+  `auto_delete_whep`（如 `30000`），避免观众短暂掉线导致硬件反复启停。
+  每流覆盖配置在 `[stream.<name>.strategy]` 下。
+- 服务器关闭时不会触发 hook（此时不产生 `stream-down` 事件）。

--- a/docs/zh/guide/live777.md
+++ b/docs/zh/guide/live777.md
@@ -127,9 +127,9 @@ listen = "0.0.0.0:8554"
 
 ## 流钩子（Stream Hooks）
 
-Live777 可以在流创建或销毁时执行外部脚本。典型用途是按需激活源：当 WHEP
-观众触发 `auto_create_whep` 建流时，hook 启动采集设备 / 硬件编码器；流销
-毁时，hook 再把它关掉以节省资源。
+Live777 可以在流创建或删除时执行外部脚本。典型用途是按需激活源：当 WHEP
+观众触发 `auto_create_whep` 建流时，hook 启动采集设备 / 硬件编码器；流删
+除时，hook 再把它关掉以节省资源。
 
 ```toml
 # 全局 hook，对所有流生效
@@ -137,21 +137,21 @@ Live777 可以在流创建或销毁时执行外部脚本。典型用途是按需
 timeout_ms = 5000    # 单个脚本超时（毫秒），0 表示不限制
 on_error = "stop"    # "stop"：脚本失败后跳过本事件剩余 hook；
                      # "continue"：失败后仍继续执行
-on_stream_up   = ["/etc/live777/hooks/notify.sh"]
-on_stream_down = ["/etc/live777/hooks/notify.sh", "/etc/live777/hooks/cleanup.sh"]
+on_stream_created   = ["/etc/live777/hooks/notify.sh"]
+on_stream_deleted = ["/etc/live777/hooks/notify.sh", "/etc/live777/hooks/cleanup.sh"]
 
 # 每流 hook，在全局 hook 之后执行
 [stream.cam1.hooks]
-on_stream_up   = ["/etc/live777/hooks/cam1-up.sh"]
-on_stream_down = ["/etc/live777/hooks/cam1-down.sh"]
+on_stream_created   = ["/etc/live777/hooks/cam1-up.sh"]
+on_stream_deleted = ["/etc/live777/hooks/cam1-down.sh"]
 ```
 
 执行保证：
 
 - 同一事件的 hook 按顺序串行执行：先全局、后每流，各自按配置顺序。
 - 所有事件共用一个 FIFO 队列处理——前一事件的全部 hook 执行完毕后，后
-  一事件的第一个 hook 才开始，因此同一条流的 `stream-up` hook 一定先于
-  它的 `stream-down` hook 执行完。
+  一事件的第一个 hook 才开始，因此同一条流的 `stream-created` hook 一定先于
+  它的 `stream-deleted` hook 执行完。
 - 脚本失败（非零退出、启动失败、超时被杀）只会被记录并按 `on_error` 处
   理，不会影响后续事件，也不会影响服务器本身。
 
@@ -160,17 +160,17 @@ on_stream_down = ["/etc/live777/hooks/cam1-down.sh"]
 
 | argv          | 环境变量          | 取值                                                                               |
 | ------------- | ----------------- | ---------------------------------------------------------------------------------- |
-| `$1`          | `LIVE777_EVENT`   | `stream-up` / `stream-down`                                                        |
+| `$1`          | `LIVE777_EVENT`   | `stream-created` / `stream-deleted`                                                        |
 | `$2`          | `LIVE777_STREAM`  | 流名                                                                               |
-| `$3`（仅 down）| `LIVE777_REASON`  | `api-deleted` / `publish-leave-timeout` / `subscribe-leave-timeout` / `orphaned`   |
+| `$3`（仅删除时）| `LIVE777_REASON`  | `api-deleted` / `publish-leave-timeout` / `subscribe-leave-timeout` / `orphaned`   |
 
 注意事项：
 
 - 脚本应在发起工作后尽快返回（例如把编码器放到后台启动）。脚本阻塞多久，
   整个 hook 队列就阻塞多久。
 - 脚本要幂等：推流端自身死亡（`publish-leave-timeout`）也会触发
-  `stream-down` hook，停止脚本必须能容忍设备已经停止的状态。
+  `stream-deleted` hook，停止脚本必须能容忍设备已经停止的状态。
 - 做按需源时，配合 `[strategy] auto_create_whep = true` 和较大的
   `auto_delete_whep`（如 `30000`），避免观众短暂掉线导致硬件反复启停。
   每流覆盖配置在 `[stream.<name>.strategy]` 下。
-- 服务器关闭时不会触发 hook（此时不产生 `stream-down` 事件）。
+- 服务器关闭时不会触发 hook（此时不产生 `stream-deleted` 事件）。

--- a/docs/zh/guide/live777.md
+++ b/docs/zh/guide/live777.md
@@ -142,8 +142,8 @@ on_stream_deleted = ["/etc/live777/hooks/notify.sh", "/etc/live777/hooks/cleanup
 
 # 每流 hook，在全局 hook 之后执行
 [stream.cam1.hooks]
-on_stream_created   = ["/etc/live777/hooks/cam1-up.sh"]
-on_stream_deleted = ["/etc/live777/hooks/cam1-down.sh"]
+on_stream_created   = ["/etc/live777/hooks/cam1-created.sh"]
+on_stream_deleted = ["/etc/live777/hooks/cam1-deleted.sh"]
 ```
 
 执行保证：

--- a/docs/zh/guide/live777.md
+++ b/docs/zh/guide/live777.md
@@ -137,12 +137,12 @@ Live777 可以在流创建或删除时执行外部脚本。典型用途是按需
 timeout_ms = 5000    # 单个脚本超时（毫秒），0 表示不限制
 on_error = "stop"    # "stop"：脚本失败后跳过本事件剩余 hook；
                      # "continue"：失败后仍继续执行
-on_stream_created   = ["/etc/live777/hooks/notify.sh"]
+on_stream_created = ["/etc/live777/hooks/notify.sh"]
 on_stream_deleted = ["/etc/live777/hooks/notify.sh", "/etc/live777/hooks/cleanup.sh"]
 
 # 每流 hook，在全局 hook 之后执行
 [stream.cam1.hooks]
-on_stream_created   = ["/etc/live777/hooks/cam1-created.sh"]
+on_stream_created = ["/etc/live777/hooks/cam1-created.sh"]
 on_stream_deleted = ["/etc/live777/hooks/cam1-deleted.sh"]
 ```
 

--- a/liveion/Cargo.toml
+++ b/liveion/Cargo.toml
@@ -31,7 +31,7 @@ reqwest = { workspace = true, features = ["json"], optional = true }
 rand = "0.10"
 serde = { workspace = true, features = ["serde_derive"] }
 serde_json = { workspace = true }
-tokio = { workspace = true, features = ["fs"] }
+tokio = { workspace = true, features = ["fs", "process", "time"] }
 tokio-stream = { version = "0.1.15", features = ["sync"] }
 tokio-util = { workspace = true }
 async-stream = "0.3.5"

--- a/liveion/src/config.rs
+++ b/liveion/src/config.rs
@@ -17,6 +17,9 @@ pub struct Config {
     pub strategy: api::strategy::Strategy,
 
     #[serde(default)]
+    pub hooks: HooksConfig,
+
+    #[serde(default)]
     pub sdp: Sdp,
 
     #[serde(default)]
@@ -247,6 +250,54 @@ mod webrtc_tests {
     }
 }
 
+#[cfg(test)]
+mod hook_tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_global_and_per_stream_hooks() {
+        let cfg: Config = toml::from_str(
+            r#"
+            [hooks]
+            timeout_ms = 3000
+            on_error = "continue"
+            on_stream_up = ["/global/up.sh"]
+            on_stream_down = ["/global/down.sh", "/global/down2.sh"]
+
+            [stream.cam1.hooks]
+            on_stream_up = ["/per-stream/up.sh"]
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(cfg.hooks.timeout_ms, 3000);
+        assert_eq!(cfg.hooks.on_error, OnError::Continue);
+        assert_eq!(cfg.hooks.hooks.on_stream_up, ["/global/up.sh"]);
+        assert_eq!(
+            cfg.hooks.hooks.on_stream_down,
+            ["/global/down.sh", "/global/down2.sh"]
+        );
+        let entry = cfg.stream.streams.get("cam1").unwrap();
+        assert_eq!(entry.hooks.on_stream_up, ["/per-stream/up.sh"]);
+        assert!(entry.hooks.on_stream_down.is_empty());
+    }
+
+    #[test]
+    fn hooks_default_to_disabled_with_sane_policy() {
+        let cfg: Config = toml::from_str("").unwrap();
+        assert_eq!(cfg.hooks.timeout_ms, 5000);
+        assert_eq!(cfg.hooks.on_error, OnError::Stop);
+        assert!(cfg.hooks.hooks.on_stream_up.is_empty());
+        assert!(cfg.hooks.hooks.on_stream_down.is_empty());
+    }
+
+    #[test]
+    fn zero_timeout_disables_the_timeout() {
+        let cfg: Config = toml::from_str("[hooks]\ntimeout_ms = 0\n").unwrap();
+        assert_eq!(cfg.hooks.timeout_ms, 0);
+    }
+}
+
 fn default_log_level() -> String {
     env::var("LOG_LEVEL").unwrap_or_else(|_| {
         if cfg!(debug_assertions) {
@@ -401,6 +452,62 @@ fn default_upload_interval_ms() -> u64 {
 fn default_upload_concurrency() -> usize {
     2
 }
+/// What to do when a hook script fails (non-zero exit, spawn error, or
+/// timeout kill).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum OnError {
+    /// Skip the remaining hooks of the same event.
+    #[default]
+    Stop,
+    /// Run every hook of the event even if an earlier one failed.
+    Continue,
+}
+
+/// Hook scripts for stream-lifecycle events. Used both globally (`[hooks]`)
+/// and per stream (`[stream.<name>.hooks]`); per-stream scripts run after
+/// the global ones.
+///
+/// Scripts are executed directly (no shell). Each receives the event
+/// metadata as argv (`<event> <stream> [reason]`) and as the environment
+/// variables `LIVE777_EVENT` / `LIVE777_STREAM` / `LIVE777_REASON`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HookConfig {
+    /// Scripts run, in order, when a stream is created.
+    #[serde(default)]
+    pub on_stream_up: Vec<String>,
+    /// Scripts run, in order, when a stream is destroyed.
+    #[serde(default)]
+    pub on_stream_down: Vec<String>,
+}
+
+/// Global `[hooks]` section: hook scripts plus execution policy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HooksConfig {
+    #[serde(flatten)]
+    pub hooks: HookConfig,
+    /// Per-script timeout in milliseconds; 0 disables the timeout.
+    #[serde(default = "default_hook_timeout_ms")]
+    pub timeout_ms: u64,
+    /// Whether a failed script skips the remaining hooks of the same event.
+    #[serde(default)]
+    pub on_error: OnError,
+}
+
+impl Default for HooksConfig {
+    fn default() -> Self {
+        Self {
+            hooks: HookConfig::default(),
+            timeout_ms: default_hook_timeout_ms(),
+            on_error: OnError::default(),
+        }
+    }
+}
+
+fn default_hook_timeout_ms() -> u64 {
+    5_000
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct StreamConfig {
     /// Per-stream configuration, keyed by stream name.
@@ -430,6 +537,9 @@ pub struct StreamEntry {
     /// Optional per-stream strategy override.
     #[serde(default)]
     pub strategy: Option<api::strategy::Strategy>,
+    /// Optional per-stream hooks, run after the global `[hooks]`.
+    #[serde(default)]
+    pub hooks: HookConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/liveion/src/config.rs
+++ b/liveion/src/config.rs
@@ -261,25 +261,25 @@ mod hook_tests {
             [hooks]
             timeout_ms = 3000
             on_error = "continue"
-            on_stream_up = ["/global/up.sh"]
-            on_stream_down = ["/global/down.sh", "/global/down2.sh"]
+            on_stream_created = ["/global/up.sh"]
+            on_stream_deleted = ["/global/down.sh", "/global/down2.sh"]
 
             [stream.cam1.hooks]
-            on_stream_up = ["/per-stream/up.sh"]
+            on_stream_created = ["/per-stream/up.sh"]
             "#,
         )
         .unwrap();
 
         assert_eq!(cfg.hooks.timeout_ms, 3000);
         assert_eq!(cfg.hooks.on_error, OnError::Continue);
-        assert_eq!(cfg.hooks.hooks.on_stream_up, ["/global/up.sh"]);
+        assert_eq!(cfg.hooks.hooks.on_stream_created, ["/global/up.sh"]);
         assert_eq!(
-            cfg.hooks.hooks.on_stream_down,
+            cfg.hooks.hooks.on_stream_deleted,
             ["/global/down.sh", "/global/down2.sh"]
         );
         let entry = cfg.stream.streams.get("cam1").unwrap();
-        assert_eq!(entry.hooks.on_stream_up, ["/per-stream/up.sh"]);
-        assert!(entry.hooks.on_stream_down.is_empty());
+        assert_eq!(entry.hooks.on_stream_created, ["/per-stream/up.sh"]);
+        assert!(entry.hooks.on_stream_deleted.is_empty());
     }
 
     #[test]
@@ -287,8 +287,8 @@ mod hook_tests {
         let cfg: Config = toml::from_str("").unwrap();
         assert_eq!(cfg.hooks.timeout_ms, 5000);
         assert_eq!(cfg.hooks.on_error, OnError::Stop);
-        assert!(cfg.hooks.hooks.on_stream_up.is_empty());
-        assert!(cfg.hooks.hooks.on_stream_down.is_empty());
+        assert!(cfg.hooks.hooks.on_stream_created.is_empty());
+        assert!(cfg.hooks.hooks.on_stream_deleted.is_empty());
     }
 
     #[test]
@@ -475,10 +475,10 @@ pub enum OnError {
 pub struct HookConfig {
     /// Scripts run, in order, when a stream is created.
     #[serde(default)]
-    pub on_stream_up: Vec<String>,
-    /// Scripts run, in order, when a stream is destroyed.
+    pub on_stream_created: Vec<String>,
+    /// Scripts run, in order, when a stream is deleted.
     #[serde(default)]
-    pub on_stream_down: Vec<String>,
+    pub on_stream_deleted: Vec<String>,
 }
 
 /// Global `[hooks]` section: hook scripts plus execution policy.

--- a/liveion/src/event.rs
+++ b/liveion/src/event.rs
@@ -5,8 +5,8 @@
 //!
 //! - SSE `/api/sse/streams` and net4mqtt — snapshot consumers that treat every
 //!   event as a "something changed" ping and re-send a full snapshot.
-//! - recorder — reacts to `StreamUp`/`StreamDown` for auto start/stop.
-//! - hook — runs user scripts on `StreamUp`/`StreamDown`. It cannot
+//! - recorder — reacts to `StreamCreated`/`StreamDeleted` for auto start/stop.
+//! - hook — runs user scripts on `StreamCreated`/`StreamDeleted`. It cannot
 //!   reconcile after lag (a missed script cannot be rerun), so its
 //!   dispatcher only forwards events into an internal queue and never
 //!   awaits a script while holding the bus receiver.
@@ -20,7 +20,7 @@
 
 /// Why a stream was torn down.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum StreamDownReason {
+pub enum StreamDeleteReason {
     /// Admin API (`DELETE /api/streams/{stream}`) or a session-kick cascade.
     ApiDeleted,
     /// `strategy.auto_delete_whip` fired after the publisher left.
@@ -33,7 +33,7 @@ pub enum StreamDownReason {
 
 /// Why a publish/subscribe session ended.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum SessionDownReason {
+pub enum SessionStopReason {
     /// The PeerConnection reached `Closed` (including the `Failed` -> close ->
     /// `Closed` cascade and stream teardown closing live sessions).
     PeerClosed,
@@ -49,32 +49,32 @@ pub enum SessionDownReason {
 pub enum Event {
     /// The stream now exists in the manager (created via API, auto-create, or
     /// source startup).
-    StreamUp { stream: String },
+    StreamCreated { stream: String },
     /// The stream was removed from the manager.
-    StreamDown {
+    StreamDeleted {
         stream: String,
-        reason: StreamDownReason,
+        reason: StreamDeleteReason,
     },
     /// A WHIP/cascade publisher session was established.
-    PublishUp { stream: String, session: String },
+    PublishStarted { stream: String, session: String },
     /// A publisher session ended.
-    PublishDown {
+    PublishStopped {
         stream: String,
         session: String,
-        reason: SessionDownReason,
+        reason: SessionStopReason,
     },
     /// A WHIP/cascade subscriber session was established.
-    SubscribeUp { stream: String, session: String },
+    SubscribeStarted { stream: String, session: String },
     /// A subscriber session ended.
-    SubscribeDown {
+    SubscribeStopped {
         stream: String,
         session: String,
-        reason: SessionDownReason,
+        reason: SessionStopReason,
     },
     /// Content-free "stream state changed" ping for snapshot consumers (SSE,
     /// net4mqtt). Fired alongside every publish/subscribe transition above,
-    /// plus track, connection-state, and closed-session changes. `StreamUp`/
-    /// `StreamDown` are emitted by the manager and carry no paired ping —
+    /// plus track, connection-state, and closed-session changes. `StreamCreated`/
+    /// `StreamDeleted` are emitted by the manager and carry no paired ping —
     /// snapshot consumers must treat every event as a change hint anyway.
     ForwardChanged { stream: String },
 }
@@ -82,12 +82,12 @@ pub enum Event {
 impl Event {
     pub fn stream(&self) -> &str {
         match self {
-            Event::StreamUp { stream }
-            | Event::StreamDown { stream, .. }
-            | Event::PublishUp { stream, .. }
-            | Event::PublishDown { stream, .. }
-            | Event::SubscribeUp { stream, .. }
-            | Event::SubscribeDown { stream, .. }
+            Event::StreamCreated { stream }
+            | Event::StreamDeleted { stream, .. }
+            | Event::PublishStarted { stream, .. }
+            | Event::PublishStopped { stream, .. }
+            | Event::SubscribeStarted { stream, .. }
+            | Event::SubscribeStopped { stream, .. }
             | Event::ForwardChanged { stream } => stream,
         }
     }

--- a/liveion/src/event.rs
+++ b/liveion/src/event.rs
@@ -6,6 +6,10 @@
 //! - SSE `/api/sse/streams` and net4mqtt — snapshot consumers that treat every
 //!   event as a "something changed" ping and re-send a full snapshot.
 //! - recorder — reacts to `StreamUp`/`StreamDown` for auto start/stop.
+//! - hook — runs user scripts on `StreamUp`/`StreamDown`. It cannot
+//!   reconcile after lag (a missed script cannot be rerun), so its
+//!   dispatcher only forwards events into an internal queue and never
+//!   awaits a script while holding the bus receiver.
 //! - the manager's event logger — emits one canonical debug line per event
 //!   with its full payload.
 //!

--- a/liveion/src/forward/internal.rs
+++ b/liveion/src/forward/internal.rs
@@ -12,7 +12,7 @@ use tracing::{debug, info, warn};
 use crate::AppError;
 #[cfg(feature = "source")]
 use crate::config::ChannelConfig;
-use crate::event::{Event, SessionDownReason};
+use crate::event::{Event, SessionStopReason};
 use crate::forward::codec_compat::{is_av1_codec, is_h264_codec, is_h265_codec};
 use crate::forward::message::{ForwardInfo, SessionInfo};
 use crate::forward::rtcp::RtcpMessage;
@@ -969,7 +969,7 @@ impl PeerForwardInternal {
                 let old = publish.take().unwrap();
                 drop(publish);
                 let _ = old.peer.close().await;
-                self.do_remove_publish_cleanup(session_info, SessionDownReason::ApiDeleted)
+                self.do_remove_publish_cleanup(session_info, SessionStopReason::ApiDeleted)
                     .await;
                 return Ok(RemovePeerOutcome::PublisherRemoved);
             }
@@ -986,7 +986,7 @@ impl PeerForwardInternal {
                 if is_empty {
                     *self.subscribe_leave_at.write().await = Utc::now().timestamp_millis();
                 }
-                self.do_remove_subscribe_cleanup(&old, SessionDownReason::ApiDeleted)
+                self.do_remove_subscribe_cleanup(&old, SessionStopReason::ApiDeleted)
                     .await;
                 let _ = old.peer.close().await;
                 // Orphan hint: with the publisher already gone and no
@@ -1215,7 +1215,7 @@ impl PeerForwardInternal {
         }
 
         metrics::PUBLISH.inc();
-        self.emit(Event::PublishUp {
+        self.emit(Event::PublishStarted {
             stream: self.stream.clone(),
             session: session_id.clone(),
         });
@@ -1245,7 +1245,7 @@ impl PeerForwardInternal {
             session_info
         };
 
-        self.do_remove_publish_cleanup(closed_session, SessionDownReason::PeerClosed)
+        self.do_remove_publish_cleanup(closed_session, SessionStopReason::PeerClosed)
             .await;
         Ok(())
     }
@@ -1256,7 +1256,7 @@ impl PeerForwardInternal {
     async fn do_remove_publish_cleanup(
         &self,
         closed_session: SessionInfo,
-        reason: SessionDownReason,
+        reason: SessionStopReason,
     ) {
         *self.publish_peer_state_rx.lock().await = None;
         // Drop the weak peer ref as well: while it is set, a late `on_track`
@@ -1283,7 +1283,7 @@ impl PeerForwardInternal {
 
         info!("[{}] [publish] set none", self.stream);
         metrics::PUBLISH.dec();
-        self.emit(Event::PublishDown {
+        self.emit(Event::PublishStopped {
             stream: self.stream.clone(),
             session: session_id,
             reason,
@@ -1857,7 +1857,7 @@ impl PeerForwardInternal {
         }
 
         metrics::SUBSCRIBE.inc();
-        self.emit(Event::SubscribeUp {
+        self.emit(Event::SubscribeStarted {
             stream: self.stream.clone(),
             session: session_id.clone(),
         });
@@ -1889,7 +1889,7 @@ impl PeerForwardInternal {
             old
         };
 
-        self.do_remove_subscribe_cleanup(&old, SessionDownReason::PeerClosed)
+        self.do_remove_subscribe_cleanup(&old, SessionStopReason::PeerClosed)
             .await;
         Ok(())
     }
@@ -1897,12 +1897,12 @@ impl PeerForwardInternal {
     /// Shared cleanup after a subscribe session has been removed from
     /// `self.subscribe_group`.  The caller must have already removed the entry
     /// from the vec (so the write lock is released before this runs) and
-    /// finalized `subscribe_leave_at`, since this emits the `SubscribeDown`
+    /// finalized `subscribe_leave_at`, since this emits the `SubscribeStopped`
     /// event and the paired `ForwardChanged` ping itself.
     async fn do_remove_subscribe_cleanup(
         &self,
         subscribe: &SubscribeRTCPeerConnection,
-        reason: SessionDownReason,
+        reason: SessionStopReason,
     ) {
         #[cfg(feature = "cascade")]
         if let Some(cascade) = subscribe.cascade.clone() {
@@ -1930,7 +1930,7 @@ impl PeerForwardInternal {
         }
 
         metrics::SUBSCRIBE.dec();
-        self.emit(Event::SubscribeDown {
+        self.emit(Event::SubscribeStopped {
             stream: self.stream.clone(),
             session: session_id,
             reason,

--- a/liveion/src/forward/mod.rs
+++ b/liveion/src/forward/mod.rs
@@ -1186,9 +1186,9 @@ a=end-of-candidates";
         Ok(())
     }
 
-    /// The lifecycle bus must carry PublishUp and PublishDown with the session
+    /// The lifecycle bus must carry PublishStarted and PublishStopped with the session
     /// ID returned by the API, and a session-API delete must surface as
-    /// `SessionDownReason::ApiDeleted`.
+    /// `SessionStopReason::ApiDeleted`.
     #[tokio::test]
     async fn publish_lifecycle_emits_typed_events() -> crate::result::Result<()> {
         let mut media_engine = MediaEngine::default();
@@ -1241,20 +1241,20 @@ a=end-of-candidates";
         let (_answer, session) = forward.set_publish(offer).await?;
 
         // Connection-state pings may interleave; skip until the typed
-        // PublishUp for this session shows up.
+        // PublishStarted for this session shows up.
         let up = tokio::time::timeout(std::time::Duration::from_secs(3), async {
             loop {
                 match event_rx.recv().await {
-                    Ok(crate::event::Event::PublishUp { stream, session }) => {
+                    Ok(crate::event::Event::PublishStarted { stream, session }) => {
                         break (stream, session);
                     }
                     Ok(_) => continue,
-                    Err(err) => panic!("event bus error before PublishUp: {err}"),
+                    Err(err) => panic!("event bus error before PublishStarted: {err}"),
                 }
             }
         })
         .await
-        .expect("timed out waiting for PublishUp");
+        .expect("timed out waiting for PublishStarted");
         assert_eq!(up, ("lifecycle-test".to_owned(), session.clone()));
 
         forward.remove_peer(session.clone()).await?;
@@ -1262,21 +1262,21 @@ a=end-of-candidates";
         let down = tokio::time::timeout(std::time::Duration::from_secs(3), async {
             loop {
                 match event_rx.recv().await {
-                    Ok(crate::event::Event::PublishDown {
+                    Ok(crate::event::Event::PublishStopped {
                         stream,
                         session,
                         reason,
                     }) => break (stream, session, reason),
                     Ok(_) => continue,
-                    Err(err) => panic!("event bus error before PublishDown: {err}"),
+                    Err(err) => panic!("event bus error before PublishStopped: {err}"),
                 }
             }
         })
         .await
-        .expect("timed out waiting for PublishDown");
+        .expect("timed out waiting for PublishStopped");
         assert_eq!(down.0, "lifecycle-test");
         assert_eq!(down.1, session);
-        assert_eq!(down.2, crate::event::SessionDownReason::ApiDeleted);
+        assert_eq!(down.2, crate::event::SessionStopReason::ApiDeleted);
 
         offer_peer.close().await?;
         Ok(())

--- a/liveion/src/hook.rs
+++ b/liveion/src/hook.rs
@@ -1,14 +1,14 @@
 //! Stream-lifecycle hook scripts.
 //!
 //! A consumer of the manager's event bus (see [`crate::event`]) that runs
-//! user-configured scripts when streams are created or destroyed. Typical
+//! user-configured scripts when streams are created or deleted. Typical
 //! use: start a capture device / hardware encoder when an on-demand
 //! (`auto_create_whep`) stream appears, stop it when the stream is torn
 //! down to save resources.
 //!
 //! Execution model:
 //!
-//! - A dispatcher task forwards `StreamUp`/`StreamDown` events into an
+//! - A dispatcher task forwards `StreamCreated`/`StreamDeleted` events into an
 //!   internal unbounded queue. It never awaits a script, so slow hooks can
 //!   never overrun the broadcast buffer and lose events.
 //! - A single executor task drains the queue FIFO and runs each event's
@@ -25,26 +25,26 @@ use tokio::sync::{broadcast, mpsc};
 use tracing::{debug, warn};
 
 use crate::config::{HooksConfig, OnError, StreamConfig};
-use crate::event::{Event, StreamDownReason};
+use crate::event::{Event, StreamDeleteReason};
 use crate::stream::manager::Manager;
 
 /// One lifecycle event's worth of hook work.
 struct HookJob {
-    /// `"stream-up"` or `"stream-down"` — passed to scripts as argv[1] and
+    /// `"stream-created"` or `"stream-deleted"` — passed to scripts as argv[1] and
     /// `LIVE777_EVENT`.
     event: &'static str,
     stream: String,
-    reason: Option<StreamDownReason>,
+    reason: Option<StreamDeleteReason>,
     /// Global scripts followed by per-stream scripts, in configured order.
     scripts: Vec<String>,
 }
 
-fn reason_str(reason: StreamDownReason) -> &'static str {
+fn reason_str(reason: StreamDeleteReason) -> &'static str {
     match reason {
-        StreamDownReason::ApiDeleted => "api-deleted",
-        StreamDownReason::PublishLeaveTimeout => "publish-leave-timeout",
-        StreamDownReason::SubscribeLeaveTimeout => "subscribe-leave-timeout",
-        StreamDownReason::Orphaned => "orphaned",
+        StreamDeleteReason::ApiDeleted => "api-deleted",
+        StreamDeleteReason::PublishLeaveTimeout => "publish-leave-timeout",
+        StreamDeleteReason::SubscribeLeaveTimeout => "subscribe-leave-timeout",
+        StreamDeleteReason::Orphaned => "orphaned",
     }
 }
 
@@ -65,11 +65,12 @@ fn effective_scripts(global: &[String], per_stream: Option<&[String]>) -> Vec<St
 /// startup are not missed: the broadcast bus does not replay events sent
 /// before the subscription.
 pub fn init(manager: &Manager, hooks: HooksConfig, stream_cfg: StreamConfig) {
-    let global_empty = hooks.hooks.on_stream_up.is_empty() && hooks.hooks.on_stream_down.is_empty();
+    let global_empty =
+        hooks.hooks.on_stream_created.is_empty() && hooks.hooks.on_stream_deleted.is_empty();
     let per_stream_empty = stream_cfg
         .streams
         .values()
-        .all(|e| e.hooks.on_stream_up.is_empty() && e.hooks.on_stream_down.is_empty());
+        .all(|e| e.hooks.on_stream_created.is_empty() && e.hooks.on_stream_deleted.is_empty());
     if global_empty && per_stream_empty {
         debug!("no stream hooks configured, hook executor disabled");
         return;
@@ -79,15 +80,15 @@ pub fn init(manager: &Manager, hooks: HooksConfig, stream_cfg: StreamConfig) {
     // are reported (and counted by on_error) at run time like any failure.
     let all_scripts = hooks
         .hooks
-        .on_stream_up
+        .on_stream_created
         .iter()
-        .chain(&hooks.hooks.on_stream_down)
-        .chain(
-            stream_cfg
-                .streams
-                .values()
-                .flat_map(|e| e.hooks.on_stream_up.iter().chain(&e.hooks.on_stream_down)),
-        );
+        .chain(&hooks.hooks.on_stream_deleted)
+        .chain(stream_cfg.streams.values().flat_map(|e| {
+            e.hooks
+                .on_stream_created
+                .iter()
+                .chain(&e.hooks.on_stream_deleted)
+        }));
     for script in all_scripts {
         if !std::path::Path::new(script).exists() {
             warn!("hook script does not exist : {}", script);
@@ -104,33 +105,33 @@ pub fn init(manager: &Manager, hooks: HooksConfig, stream_cfg: StreamConfig) {
     tokio::spawn(async move {
         loop {
             let job = match events.recv().await {
-                Ok(Event::StreamUp { stream }) => HookJob {
-                    event: "stream-up",
+                Ok(Event::StreamCreated { stream }) => HookJob {
+                    event: "stream-created",
                     scripts: effective_scripts(
-                        &global.on_stream_up,
+                        &global.on_stream_created,
                         stream_cfg
                             .streams
                             .get(&stream)
-                            .map(|e| e.hooks.on_stream_up.as_slice()),
+                            .map(|e| e.hooks.on_stream_created.as_slice()),
                     ),
                     stream,
                     reason: None,
                 },
-                Ok(Event::StreamDown { stream, reason }) => HookJob {
-                    event: "stream-down",
+                Ok(Event::StreamDeleted { stream, reason }) => HookJob {
+                    event: "stream-deleted",
                     scripts: effective_scripts(
-                        &global.on_stream_down,
+                        &global.on_stream_deleted,
                         stream_cfg
                             .streams
                             .get(&stream)
-                            .map(|e| e.hooks.on_stream_down.as_slice()),
+                            .map(|e| e.hooks.on_stream_deleted.as_slice()),
                     ),
                     stream,
                     reason: Some(reason),
                 },
                 Ok(_) => continue,
                 // Unlike snapshot consumers, hooks cannot reconcile after the
-                // fact — a missed "stream-up" script cannot be rerun — so the
+                // fact — a missed "stream-created" script cannot be rerun — so the
                 // loss is surfaced loudly instead of being smoothed over.
                 Err(broadcast::error::RecvError::Lagged(n)) => {
                     warn!("hook dispatcher dropped {} stream events due to lag", n);
@@ -316,7 +317,7 @@ mod tests {
 
             let (tx, rx) = mpsc::unbounded_channel();
             let handle = tokio::spawn(executor(rx, None, OnError::Stop));
-            tx.send(job("stream-up", vec![fail, marker])).unwrap();
+            tx.send(job("stream-created", vec![fail, marker])).unwrap();
             drop(tx);
             handle.await.unwrap();
 
@@ -332,7 +333,7 @@ mod tests {
 
             let (tx, rx) = mpsc::unbounded_channel();
             let handle = tokio::spawn(executor(rx, None, OnError::Continue));
-            tx.send(job("stream-up", vec![fail, marker])).unwrap();
+            tx.send(job("stream-created", vec![fail, marker])).unwrap();
             drop(tx);
             handle.await.unwrap();
 
@@ -353,8 +354,8 @@ mod tests {
                 OnError::Stop,
             ));
             // The timed-out job stops; the *next* event must still run.
-            tx.send(job("stream-up", vec![slow])).unwrap();
-            tx.send(job("stream-down", vec![marker])).unwrap();
+            tx.send(job("stream-created", vec![slow])).unwrap();
+            tx.send(job("stream-deleted", vec![marker])).unwrap();
             drop(tx);
 
             let start = std::time::Instant::now();
@@ -371,14 +372,15 @@ mod tests {
             let dir = tempfile::tempdir().unwrap();
             let log = dir.path().join("order.log");
             // argv contract: $1 = event, $3 = reason; env: LIVE777_STREAM.
-            let up_global = log_line_script(dir.path(), "up1.sh", &log, "up-1 $LIVE777_STREAM");
-            let up_stream = log_line_script(dir.path(), "up2.sh", &log, "up-2 $1");
-            let down_global = log_line_script(dir.path(), "down.sh", &log, "down-1 $3");
+            let created_global =
+                log_line_script(dir.path(), "created1.sh", &log, "created-1 $LIVE777_STREAM");
+            let created_stream = log_line_script(dir.path(), "created2.sh", &log, "created-2 $1");
+            let deleted_global = log_line_script(dir.path(), "deleted1.sh", &log, "deleted-1 $3");
 
             let hooks = HooksConfig {
                 hooks: HookConfig {
-                    on_stream_up: vec![up_global],
-                    on_stream_down: vec![down_global],
+                    on_stream_created: vec![created_global],
+                    on_stream_deleted: vec![deleted_global],
                 },
                 timeout_ms: 5_000,
                 on_error: OnError::Stop,
@@ -388,7 +390,7 @@ mod tests {
                 "cam1".to_string(),
                 StreamEntry {
                     hooks: HookConfig {
-                        on_stream_up: vec![up_stream],
+                        on_stream_created: vec![created_stream],
                         ..Default::default()
                     },
                     ..Default::default()
@@ -405,7 +407,11 @@ mod tests {
             let content = wait_for_lines(&log, 3).await;
             assert_eq!(
                 content.lines().collect::<Vec<_>>(),
-                ["up-1 cam1", "up-2 stream-up", "down-1 api-deleted"]
+                [
+                    "created-1 cam1",
+                    "created-2 stream-created",
+                    "deleted-1 api-deleted"
+                ]
             );
             cancel.cancel();
         }

--- a/liveion/src/hook.rs
+++ b/liveion/src/hook.rs
@@ -1,0 +1,413 @@
+//! Stream-lifecycle hook scripts.
+//!
+//! A consumer of the manager's event bus (see [`crate::event`]) that runs
+//! user-configured scripts when streams are created or destroyed. Typical
+//! use: start a capture device / hardware encoder when an on-demand
+//! (`auto_create_whep`) stream appears, stop it when the stream is torn
+//! down to save resources.
+//!
+//! Execution model:
+//!
+//! - A dispatcher task forwards `StreamUp`/`StreamDown` events into an
+//!   internal unbounded queue. It never awaits a script, so slow hooks can
+//!   never overrun the broadcast buffer and lose events.
+//! - A single executor task drains the queue FIFO and runs each event's
+//!   scripts sequentially: global `[hooks]` first, then the per-stream
+//!   `[stream.<name>.hooks]`, each in configured order. All hooks of an
+//!   earlier event finish before any hook of a later event starts, which
+//!   yields a global ordering guarantee (stronger than the per-stream
+//!   ordering the events actually require).
+
+use std::process::Stdio;
+use std::time::Duration;
+
+use tokio::sync::{broadcast, mpsc};
+use tracing::{debug, warn};
+
+use crate::config::{HooksConfig, OnError, StreamConfig};
+use crate::event::{Event, StreamDownReason};
+use crate::stream::manager::Manager;
+
+/// One lifecycle event's worth of hook work.
+struct HookJob {
+    /// `"stream-up"` or `"stream-down"` — passed to scripts as argv[1] and
+    /// `LIVE777_EVENT`.
+    event: &'static str,
+    stream: String,
+    reason: Option<StreamDownReason>,
+    /// Global scripts followed by per-stream scripts, in configured order.
+    scripts: Vec<String>,
+}
+
+fn reason_str(reason: StreamDownReason) -> &'static str {
+    match reason {
+        StreamDownReason::ApiDeleted => "api-deleted",
+        StreamDownReason::PublishLeaveTimeout => "publish-leave-timeout",
+        StreamDownReason::SubscribeLeaveTimeout => "subscribe-leave-timeout",
+        StreamDownReason::Orphaned => "orphaned",
+    }
+}
+
+/// Effective hook list for one event: global scripts first, then the
+/// per-stream ones, each in configured order (mirrors `Strategy::effective`).
+fn effective_scripts(global: &[String], per_stream: Option<&[String]>) -> Vec<String> {
+    let mut scripts = global.to_vec();
+    if let Some(per_stream) = per_stream {
+        scripts.extend(per_stream.iter().cloned());
+    }
+    scripts
+}
+
+/// Spawn the hook dispatcher and executor. Both tasks are skipped entirely
+/// when no hooks are configured anywhere (the common case).
+///
+/// Must be called before any source auto-start so streams created at
+/// startup are not missed: the broadcast bus does not replay events sent
+/// before the subscription.
+pub fn init(manager: &Manager, hooks: HooksConfig, stream_cfg: StreamConfig) {
+    let global_empty = hooks.hooks.on_stream_up.is_empty() && hooks.hooks.on_stream_down.is_empty();
+    let per_stream_empty = stream_cfg
+        .streams
+        .values()
+        .all(|e| e.hooks.on_stream_up.is_empty() && e.hooks.on_stream_down.is_empty());
+    if global_empty && per_stream_empty {
+        debug!("no stream hooks configured, hook executor disabled");
+        return;
+    }
+
+    // Catch path typos early; a missing script is not fatal — spawn errors
+    // are reported (and counted by on_error) at run time like any failure.
+    let all_scripts = hooks
+        .hooks
+        .on_stream_up
+        .iter()
+        .chain(&hooks.hooks.on_stream_down)
+        .chain(
+            stream_cfg
+                .streams
+                .values()
+                .flat_map(|e| e.hooks.on_stream_up.iter().chain(&e.hooks.on_stream_down)),
+        );
+    for script in all_scripts {
+        if !std::path::Path::new(script).exists() {
+            warn!("hook script does not exist : {}", script);
+        }
+    }
+
+    let (tx, rx) = mpsc::unbounded_channel::<HookJob>();
+
+    let timeout = (hooks.timeout_ms > 0).then(|| Duration::from_millis(hooks.timeout_ms));
+    tokio::spawn(executor(rx, timeout, hooks.on_error));
+
+    let global = hooks.hooks;
+    let mut events = manager.subscribe_event();
+    tokio::spawn(async move {
+        loop {
+            let job = match events.recv().await {
+                Ok(Event::StreamUp { stream }) => HookJob {
+                    event: "stream-up",
+                    scripts: effective_scripts(
+                        &global.on_stream_up,
+                        stream_cfg
+                            .streams
+                            .get(&stream)
+                            .map(|e| e.hooks.on_stream_up.as_slice()),
+                    ),
+                    stream,
+                    reason: None,
+                },
+                Ok(Event::StreamDown { stream, reason }) => HookJob {
+                    event: "stream-down",
+                    scripts: effective_scripts(
+                        &global.on_stream_down,
+                        stream_cfg
+                            .streams
+                            .get(&stream)
+                            .map(|e| e.hooks.on_stream_down.as_slice()),
+                    ),
+                    stream,
+                    reason: Some(reason),
+                },
+                Ok(_) => continue,
+                // Unlike snapshot consumers, hooks cannot reconcile after the
+                // fact — a missed "stream-up" script cannot be rerun — so the
+                // loss is surfaced loudly instead of being smoothed over.
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    warn!("hook dispatcher dropped {} stream events due to lag", n);
+                    continue;
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            };
+            if job.scripts.is_empty() {
+                continue;
+            }
+            // The executor is gone only if this task is shutting down too.
+            if tx.send(job).is_err() {
+                break;
+            }
+        }
+    });
+}
+
+/// Drain the queue strictly in order: every script of an event is awaited
+/// before the next event's first script starts.
+async fn executor(
+    mut rx: mpsc::UnboundedReceiver<HookJob>,
+    timeout: Option<Duration>,
+    on_error: OnError,
+) {
+    while let Some(job) = rx.recv().await {
+        for script in &job.scripts {
+            if let Err(e) = run_script(script, &job, timeout).await {
+                warn!(
+                    "hook script failed, script : {}, event : {}, stream : {}, error : {}",
+                    script, job.event, job.stream, e
+                );
+                if on_error == OnError::Stop {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Run one hook script and wait for it to exit.
+///
+/// Contract: argv is `<event> <stream> [reason]`; the same values are also
+/// exported as `LIVE777_EVENT` / `LIVE777_STREAM` / `LIVE777_REASON`.
+/// Scripts should return quickly after initiating their work (e.g. launch
+/// an encoder in the background) — a blocked script blocks the whole hook
+/// queue. Non-zero exit, spawn failure, and timeout kill all count as
+/// failure and are handled per `on_error`.
+async fn run_script(script: &str, job: &HookJob, timeout: Option<Duration>) -> anyhow::Result<()> {
+    let mut cmd = tokio::process::Command::new(script);
+    cmd.arg(job.event).arg(&job.stream);
+    cmd.env("LIVE777_EVENT", job.event)
+        .env("LIVE777_STREAM", &job.stream);
+    if let Some(reason) = job.reason {
+        cmd.arg(reason_str(reason));
+        cmd.env("LIVE777_REASON", reason_str(reason));
+    }
+    // Dropping the expired timeout future drops the Child, which kills it.
+    cmd.kill_on_drop(true);
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+    debug!(
+        "running hook script, script : {}, event : {}, stream : {}",
+        script, job.event, job.stream
+    );
+    let child = cmd
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("spawn failed : {}", e))?;
+    let output = match timeout {
+        Some(t) => match tokio::time::timeout(t, child.wait_with_output()).await {
+            Ok(output) => output.map_err(|e| anyhow::anyhow!("wait failed : {}", e))?,
+            Err(_) => anyhow::bail!("timed out after {} ms", t.as_millis()),
+        },
+        None => child
+            .wait_with_output()
+            .await
+            .map_err(|e| anyhow::anyhow!("wait failed : {}", e))?,
+    };
+    if !output.stdout.is_empty() {
+        debug!(
+            "hook script stdout, script : {}, stream : {}, stdout : {}",
+            script,
+            job.stream,
+            String::from_utf8_lossy(&output.stdout).trim()
+        );
+    }
+    if output.status.success() {
+        if !output.stderr.is_empty() {
+            debug!(
+                "hook script stderr, script : {}, stream : {}, stderr : {}",
+                script,
+                job.stream,
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        return Ok(());
+    }
+    // stderr is how scripts explain failures — attach it to the error so it
+    // shows up in the warn log, not just at debug level.
+    anyhow::bail!(
+        "exit status : {}{}",
+        output.status,
+        if output.stderr.is_empty() {
+            String::new()
+        } else {
+            format!(
+                ", stderr : {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            )
+        }
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn effective_scripts_merge_global_then_per_stream() {
+        let global = vec!["/g1.sh".to_string(), "/g2.sh".to_string()];
+        let per_stream = vec!["/p1.sh".to_string()];
+
+        assert_eq!(
+            effective_scripts(&global, Some(&per_stream)),
+            ["/g1.sh", "/g2.sh", "/p1.sh"]
+        );
+        assert_eq!(effective_scripts(&global, None), ["/g1.sh", "/g2.sh"]);
+        assert!(effective_scripts(&[], None).is_empty());
+    }
+
+    #[cfg(unix)]
+    mod unix {
+        use super::*;
+        use crate::config::{Config, HookConfig, StreamConfig, StreamEntry};
+        use std::path::{Path, PathBuf};
+        use tokio_util::sync::CancellationToken;
+
+        fn write_script(dir: &Path, name: &str, body: &str) -> String {
+            use std::os::unix::fs::PermissionsExt;
+            let path = dir.join(name);
+            std::fs::write(&path, body).unwrap();
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+            path.to_str().unwrap().to_string()
+        }
+
+        /// Append-to-log script body; each invocation appends one line.
+        /// Double quotes keep `$VAR`/`$N` expansion working.
+        fn log_line_script(dir: &Path, name: &str, log: &Path, line: &str) -> String {
+            write_script(
+                dir,
+                name,
+                &format!("#!/bin/sh\necho \"{}\" >> {}\n", line, log.display()),
+            )
+        }
+
+        async fn wait_for_lines(path: &PathBuf, n: usize) -> String {
+            for _ in 0..100 {
+                if let Ok(content) = std::fs::read_to_string(path)
+                    && content.lines().count() >= n
+                {
+                    return content;
+                }
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+            panic!("timed out waiting for {} lines in {}", n, path.display());
+        }
+
+        fn job(event: &'static str, scripts: Vec<String>) -> HookJob {
+            HookJob {
+                event,
+                stream: "cam1".to_string(),
+                reason: None,
+                scripts,
+            }
+        }
+
+        #[tokio::test]
+        async fn on_error_stop_skips_remaining_hooks() {
+            let dir = tempfile::tempdir().unwrap();
+            let log = dir.path().join("order.log");
+            let fail = write_script(dir.path(), "fail.sh", "#!/bin/sh\nexit 1\n");
+            let marker = log_line_script(dir.path(), "marker.sh", &log, "marker");
+
+            let (tx, rx) = mpsc::unbounded_channel();
+            let handle = tokio::spawn(executor(rx, None, OnError::Stop));
+            tx.send(job("stream-up", vec![fail, marker])).unwrap();
+            drop(tx);
+            handle.await.unwrap();
+
+            assert!(!log.exists());
+        }
+
+        #[tokio::test]
+        async fn on_error_continue_runs_remaining_hooks() {
+            let dir = tempfile::tempdir().unwrap();
+            let log = dir.path().join("order.log");
+            let fail = write_script(dir.path(), "fail.sh", "#!/bin/sh\nexit 1\n");
+            let marker = log_line_script(dir.path(), "marker.sh", &log, "marker");
+
+            let (tx, rx) = mpsc::unbounded_channel();
+            let handle = tokio::spawn(executor(rx, None, OnError::Continue));
+            tx.send(job("stream-up", vec![fail, marker])).unwrap();
+            drop(tx);
+            handle.await.unwrap();
+
+            assert_eq!(std::fs::read_to_string(&log).unwrap(), "marker\n");
+        }
+
+        #[tokio::test]
+        async fn timeout_kills_slow_script_and_executor_continues() {
+            let dir = tempfile::tempdir().unwrap();
+            let log = dir.path().join("order.log");
+            let slow = write_script(dir.path(), "slow.sh", "#!/bin/sh\nsleep 30\n");
+            let marker = log_line_script(dir.path(), "marker.sh", &log, "marker");
+
+            let (tx, rx) = mpsc::unbounded_channel();
+            let handle = tokio::spawn(executor(
+                rx,
+                Some(Duration::from_millis(100)),
+                OnError::Stop,
+            ));
+            // The timed-out job stops; the *next* event must still run.
+            tx.send(job("stream-up", vec![slow])).unwrap();
+            tx.send(job("stream-down", vec![marker])).unwrap();
+            drop(tx);
+
+            let start = std::time::Instant::now();
+            handle.await.unwrap();
+            assert!(
+                start.elapsed() < Duration::from_secs(5),
+                "executor stayed stuck behind the slow script"
+            );
+            assert_eq!(std::fs::read_to_string(&log).unwrap(), "marker\n");
+        }
+
+        #[tokio::test]
+        async fn hooks_run_in_event_order_with_metadata() {
+            let dir = tempfile::tempdir().unwrap();
+            let log = dir.path().join("order.log");
+            // argv contract: $1 = event, $3 = reason; env: LIVE777_STREAM.
+            let up_global = log_line_script(dir.path(), "up1.sh", &log, "up-1 $LIVE777_STREAM");
+            let up_stream = log_line_script(dir.path(), "up2.sh", &log, "up-2 $1");
+            let down_global = log_line_script(dir.path(), "down.sh", &log, "down-1 $3");
+
+            let hooks = HooksConfig {
+                hooks: HookConfig {
+                    on_stream_up: vec![up_global],
+                    on_stream_down: vec![down_global],
+                },
+                timeout_ms: 5_000,
+                on_error: OnError::Stop,
+            };
+            let mut stream_cfg = StreamConfig::default();
+            stream_cfg.streams.insert(
+                "cam1".to_string(),
+                StreamEntry {
+                    hooks: HookConfig {
+                        on_stream_up: vec![up_stream],
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            );
+
+            let cancel = CancellationToken::new();
+            let manager = Manager::new(Config::default(), cancel.clone()).await;
+            init(&manager, hooks, stream_cfg);
+
+            manager.stream_create("cam1".to_string()).await.unwrap();
+            manager.stream_delete("cam1".to_string()).await.unwrap();
+
+            let content = wait_for_lines(&log, 3).await;
+            assert_eq!(
+                content.lines().collect::<Vec<_>>(),
+                ["up-1 cam1", "up-2 stream-up", "down-1 api-deleted"]
+            );
+            cancel.cancel();
+        }
+    }
+}

--- a/liveion/src/lib.rs
+++ b/liveion/src/lib.rs
@@ -30,6 +30,7 @@ mod convert;
 mod error;
 mod event;
 mod forward;
+mod hook;
 mod r#macro;
 mod metrics;
 mod result;
@@ -57,6 +58,14 @@ where
     {
         crate::recorder::init(app_state.stream_manager.clone(), cfg.recorder.clone()).await;
     }
+
+    // Hook init must precede source auto-start so streams created at
+    // startup emit their StreamUp hooks (the bus does not replay).
+    crate::hook::init(
+        &app_state.stream_manager,
+        cfg.hooks.clone(),
+        cfg.stream.clone(),
+    );
 
     #[cfg(feature = "source")]
     {

--- a/liveion/src/lib.rs
+++ b/liveion/src/lib.rs
@@ -60,7 +60,7 @@ where
     }
 
     // Hook init must precede source auto-start so streams created at
-    // startup emit their StreamUp hooks (the bus does not replay).
+    // startup emit their StreamCreated hooks (the bus does not replay).
     crate::hook::init(
         &app_state.stream_manager,
         cfg.hooks.clone(),

--- a/liveion/src/recorder/mod.rs
+++ b/liveion/src/recorder/mod.rs
@@ -132,14 +132,14 @@ pub async fn init(manager: Arc<Manager>, cfg: RecorderConfig) {
     tokio::spawn(async move {
         loop {
             match recv.recv().await {
-                Ok(Event::StreamUp { stream }) => {
+                Ok(Event::StreamCreated { stream }) => {
                     if should_record(&cfg_for_events.auto_streams, &stream)
                         && let Err(e) = start(manager_clone.clone(), stream.clone(), None).await
                     {
                         tracing::error!("[recorder] start failed: {}", e);
                     }
                 }
-                Ok(Event::StreamDown { stream, .. }) => {
+                Ok(Event::StreamDeleted { stream, .. }) => {
                     stop_task(&stream).await;
                 }
                 Ok(_) => {}

--- a/liveion/src/stream/manager.rs
+++ b/liveion/src/stream/manager.rs
@@ -928,7 +928,6 @@ impl Manager {
         forward
     }
 
-    #[cfg(any(feature = "net4mqtt", feature = "recorder"))]
     pub fn subscribe_event(&self) -> broadcast::Receiver<Event> {
         self.event_sender.subscribe()
     }

--- a/liveion/src/stream/manager.rs
+++ b/liveion/src/stream/manager.rs
@@ -1,5 +1,5 @@
 use crate::config::Config;
-use crate::event::{Event, StreamDownReason};
+use crate::event::{Event, StreamDeleteReason};
 use crate::forward::message::ForwardInfo;
 
 use crate::result::Result;
@@ -35,24 +35,24 @@ fn orphan_reap_allowed(strategy: &api::strategy::Strategy) -> bool {
 }
 
 /// Single funnel for stream-teardown bookkeeping: the metrics decrement and
-/// the `StreamDown` lifecycle event always fire as a pair.
-fn emit_stream_down(
+/// the `StreamDeleted` lifecycle event always fire as a pair.
+fn emit_stream_deleted(
     event_sender: &broadcast::Sender<Event>,
     stream: &str,
-    reason: StreamDownReason,
+    reason: StreamDeleteReason,
 ) {
     metrics::STREAM.dec();
-    let _ = event_sender.send(Event::StreamDown {
+    let _ = event_sender.send(Event::StreamDeleted {
         stream: stream.to_string(),
         reason,
     });
 }
 
-/// Mirror of [`emit_stream_down`]: the metrics increment and the `StreamUp`
+/// Mirror of [`emit_stream_deleted`]: the metrics increment and the `StreamCreated`
 /// lifecycle event always fire as a pair.
-fn emit_stream_up(event_sender: &broadcast::Sender<Event>, stream: &str) {
+fn emit_stream_created(event_sender: &broadcast::Sender<Event>, stream: &str) {
     metrics::STREAM.inc();
-    let _ = event_sender.send(Event::StreamUp {
+    let _ = event_sender.send(Event::StreamCreated {
         stream: stream.to_string(),
     });
 }
@@ -121,44 +121,44 @@ impl Manager {
                 },
             };
             match &event {
-                Event::StreamUp { stream } => {
-                    debug!("lifecycle: stream up, stream : {}", stream);
+                Event::StreamCreated { stream } => {
+                    debug!("lifecycle: stream created, stream : {}", stream);
                 }
-                Event::StreamDown { stream, reason } => {
+                Event::StreamDeleted { stream, reason } => {
                     debug!(
-                        "lifecycle: stream down, stream : {}, reason : {:?}",
+                        "lifecycle: stream deleted, stream : {}, reason : {:?}",
                         stream, reason
                     );
                 }
-                Event::PublishUp { stream, session } => {
+                Event::PublishStarted { stream, session } => {
                     debug!(
-                        "lifecycle: publish up, stream : {}, session : {}",
+                        "lifecycle: publish started, stream : {}, session : {}",
                         stream, session
                     );
                 }
-                Event::PublishDown {
+                Event::PublishStopped {
                     stream,
                     session,
                     reason,
                 } => {
                     debug!(
-                        "lifecycle: publish down, stream : {}, session : {}, reason : {:?}",
+                        "lifecycle: publish stopped, stream : {}, session : {}, reason : {:?}",
                         stream, session, reason
                     );
                 }
-                Event::SubscribeUp { stream, session } => {
+                Event::SubscribeStarted { stream, session } => {
                     debug!(
-                        "lifecycle: subscribe up, stream : {}, session : {}",
+                        "lifecycle: subscribe started, stream : {}, session : {}",
                         stream, session
                     );
                 }
-                Event::SubscribeDown {
+                Event::SubscribeStopped {
                     stream,
                     session,
                     reason,
                 } => {
                     debug!(
-                        "lifecycle: subscribe down, stream : {}, session : {}, reason : {:?}",
+                        "lifecycle: subscribe stopped, stream : {}, session : {}, reason : {:?}",
                         stream, session, reason
                     );
                 }
@@ -220,10 +220,10 @@ impl Manager {
                             stream, publish_leave_at
                         );
 
-                        emit_stream_down(
+                        emit_stream_deleted(
                             &event_sender,
                             stream,
-                            StreamDownReason::PublishLeaveTimeout,
+                            StreamDeleteReason::PublishLeaveTimeout,
                         );
                     }
                 }
@@ -301,9 +301,9 @@ impl Manager {
                     let _ = forward.close().await;
                     stream_map.remove(stream);
                     let reason = if orphaned {
-                        StreamDownReason::Orphaned
+                        StreamDeleteReason::Orphaned
                     } else {
-                        StreamDownReason::SubscribeLeaveTimeout
+                        StreamDeleteReason::SubscribeLeaveTimeout
                     };
                     let subscribe_leave_at = DateTime::from_timestamp_millis(subscribe_leave_at)
                         .unwrap()
@@ -321,7 +321,7 @@ impl Manager {
                         );
                     }
 
-                    emit_stream_down(&event_sender, stream, reason);
+                    emit_stream_deleted(&event_sender, stream, reason);
                 }
             }
         }
@@ -371,7 +371,7 @@ impl Manager {
 
     fn register_stream_created(&self, stream: &str) {
         info!("add stream : {}", stream);
-        emit_stream_up(&self.event_sender, stream);
+        emit_stream_created(&self.event_sender, stream);
     }
 
     async fn init_stream_forward(&self, stream: &str, forward: &PeerForward) {
@@ -401,7 +401,7 @@ impl Manager {
     }
 
     async fn do_stream_delete(&self, stream: String) {
-        emit_stream_down(&self.event_sender, &stream, StreamDownReason::ApiDeleted);
+        emit_stream_deleted(&self.event_sender, &stream, StreamDeleteReason::ApiDeleted);
     }
 
     pub async fn publish(&self, stream: String, offer: RTCSessionDescription) -> Result<Response> {
@@ -946,7 +946,7 @@ mod tests {
     use tokio::time::{Duration, timeout};
 
     #[tokio::test]
-    async fn concurrent_auto_create_emits_one_stream_up_event() {
+    async fn concurrent_auto_create_emits_one_stream_created_event() {
         let cancel = CancellationToken::new();
         let manager = Manager::new(Config::default(), cancel).await;
         let mut events = manager.event_sender.subscribe();
@@ -966,15 +966,15 @@ mod tests {
 
         assert!(results.iter().all(Option::is_some));
 
-        let mut up_events = 0;
+        let mut created_events = 0;
         while let Ok(Ok(event)) = timeout(Duration::from_millis(50), events.recv()).await {
-            if let Event::StreamUp { stream: s } = event
+            if let Event::StreamCreated { stream: s } = event
                 && s == stream
             {
-                up_events += 1;
+                created_events += 1;
             }
         }
 
-        assert_eq!(up_events, 1);
+        assert_eq!(created_events, 1);
     }
 }

--- a/src/bin/datachannel_loadtest.rs
+++ b/src/bin/datachannel_loadtest.rs
@@ -167,6 +167,7 @@ async fn setup_topology(
         liveion::config::StreamEntry {
             sources: vec![],
             strategy: None,
+            hooks: Default::default(),
             channel: Some(liveion::config::ChannelConfig {
                 listen: format!("0.0.0.0:{liveion_ch_listen}").parse().unwrap(),
                 target: format!("{}:{liveion_ch_target}", args.target_host)

--- a/tests/channel.rs
+++ b/tests/channel.rs
@@ -74,6 +74,7 @@ async fn test_whepfrom_datachannel_udp_forwarding() {
         liveion::config::StreamEntry {
             sources: vec![],
             strategy: None,
+            hooks: Default::default(),
             channel: Some(liveion::config::ChannelConfig {
                 listen: format!("0.0.0.0:{liveion_ch_listen}").parse().unwrap(),
                 target: format!("127.0.0.1:{liveion_ch_target}").parse().unwrap(),


### PR DESCRIPTION
## Summary

Adds a hook mechanism that runs user-configured scripts when streams are created or deleted. A typical use is on-demand source activation: when a WHEP subscriber triggers `auto_create_whep`, a hook starts a capture device / hardware encoder; when the stream is torn down, the hook stops it again to save resources.

- New `[hooks]` section (global) and `[stream.<name>.hooks]` (per stream), merged global-first like `Strategy::effective`
- The hooks consumer is a fourth subscriber of the manager's lifecycle event bus: a dispatcher forwards `StreamCreated`/`StreamDeleted` into an internal unbounded queue without awaiting scripts (slow scripts can never overrun the broadcast buffer), and a single FIFO executor runs each event's scripts sequentially — global first, then per-stream, in configured order — so all hooks of an earlier event finish before any hook of a later event starts
- Scripts are executed directly (no shell) and receive `<event> <stream> [reason]` as argv plus `LIVE777_EVENT` / `LIVE777_STREAM` / `LIVE777_REASON` as env; per-script timeout kill (`timeout_ms`, default 5000, 0 disables) and `on_error = stop|continue` policy (default `stop`)
- `Manager::subscribe_event()` loses its feature gate; no new third-party dependencies; the whole mechanism is a no-op when no hooks are configured
- Lifecycle events renamed to match their domain verbs (second commit): `StreamUp`/`StreamDown` → `StreamCreated`/`StreamDeleted`, `PublishUp`/`PublishDown` → `PublishStarted`/`PublishStopped`, `SubscribeUp`/`SubscribeDown` → `SubscribeStarted`/`SubscribeStopped`, `StreamDownReason` → `StreamDeleteReason`, `SessionDownReason` → `SessionStopReason` (all pre-release, no compat concern)
- Docs: `docs/guide/live777.md` (+ zh), `conf/live777.toml` example, CHANGELOG entry, AGENTS.md / event.rs consumer list

## Test plan

- [x] New unit tests (8): hook-list merge order, TOML parsing/defaults, `on_error` stop/continue, timeout kill with executor continuation, end-to-end ordering through `Manager` (script-execution tests gated on `cfg(unix)`)
- [x] `cargo test -p liveion` (52) and with `source-all,recorder,net4mqtt,cascade,rtsp` (102) pass
- [x] `cargo clippy` clean with `-D warnings` in both feature sets; `cargo fmt --check` clean
- [x] Manual smoke: `POST /api/streams/cam1` → global created-hook fired; `DELETE` → per-stream deleted-hook fired with `api-deleted` reason (argv + env verified)
- [x] CI (incl. a fix for two exhaustive `StreamEntry` initializers only built under `--all-features`)