### PR TITLE
feat(liveion): replace SDP codec blacklist with per-media whitelists

### DIFF
--- a/conf/live777.toml
+++ b/conf/live777.toml
@@ -218,9 +218,12 @@ root = "./storage"
 # level = "warn"
 
 [sdp]
-# Disable codecs in SDP negotiation (useful for recorder-only pipelines)
-# Available: VP8, VP9, H264, H265, AV1, OPUS, G722, PCMU, PCMA
-# disable_codecs = ["VP8", "H264"]
+# Restrict codecs in SDP negotiation (useful for recorder-only pipelines)
+# Whitelist per media type; empty or omitted means no restriction
+# Available video: VP8, VP9, H264, H265, AV1
+# Available audio: OPUS, G722, PCMU, PCMA
+# video_codecs = ["H264"]
+# audio_codecs = ["OPUS"]
 
 [strategy]
 # If not set, use default u16::MAX

--- a/liveion/src/config.rs
+++ b/liveion/src/config.rs
@@ -81,9 +81,16 @@ pub struct Log {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Sdp {
-    /// Disable specific codecs in SDP negotiation, e.g. ["VP8", "H264"]
+    /// Only allow these video codecs in SDP negotiation, e.g. ["H264"].
+    /// Empty means no restriction.
+    /// Available: VP8, VP9, H264, H265, AV1
     #[serde(default)]
-    pub disable_codecs: Vec<String>,
+    pub video_codecs: Vec<String>,
+    /// Only allow these audio codecs in SDP negotiation, e.g. ["OPUS"].
+    /// Empty means no restriction.
+    /// Available: OPUS, G722, PCMU, PCMA
+    #[serde(default)]
+    pub audio_codecs: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/liveion/src/route/sdp.rs
+++ b/liveion/src/route/sdp.rs
@@ -2,34 +2,103 @@ use std::collections::{HashMap, HashSet};
 
 use anyhow::{Result, anyhow};
 
-pub fn maybe_filter_codecs(sdp: &str, disabled_codecs: &[String]) -> Result<String> {
-    let disabled: HashSet<String> = disabled_codecs
-        .iter()
-        .map(|c| c.trim().to_ascii_uppercase())
-        .filter(|c| !c.is_empty())
-        .collect();
-    if disabled.is_empty() {
+/// Metadata of one RTP payload type collected from the offer.
+#[derive(Default)]
+struct Payload {
+    /// Media type of the enclosing m= section, e.g. "video" / "audio".
+    media: String,
+    /// Codec name from a=rtpmap, uppercase; empty for static payload types.
+    codec: String,
+    /// Base payload referenced via a=fmtp apt= (e.g. RTX retransmission).
+    apt: Option<String>,
+}
+
+/// Filter an SDP offer down to the configured codec whitelists.
+///
+/// `video_codecs` / `audio_codecs` list the only codecs allowed for that media
+/// type; an empty list means no restriction. Codec-associated payloads such as
+/// RTX retransmission follow the codec they reference via `fmtp apt=` instead
+/// of being judged by their own name. Payloads without an `a=rtpmap` entry
+/// (static payload types) are kept as-is.
+pub fn maybe_filter_codecs(
+    sdp: &str,
+    video_codecs: &[String],
+    audio_codecs: &[String],
+) -> Result<String> {
+    let video_whitelist = normalize(video_codecs);
+    let audio_whitelist = normalize(audio_codecs);
+    if video_whitelist.is_empty() && audio_whitelist.is_empty() {
         return Ok(sdp.to_string());
     }
 
-    let mut pt_to_codec: HashMap<String, String> = HashMap::new();
+    // First pass: collect payload metadata per media section.
+    let mut payloads: HashMap<String, Payload> = HashMap::new();
+    let mut current_media = String::new();
+
     for line in sdp.lines() {
+        if let Some(rest) = line.strip_prefix("m=") {
+            current_media = rest
+                .split_whitespace()
+                .next()
+                .unwrap_or_default()
+                .to_string();
+            continue;
+        }
         if let Some(rest) = line.strip_prefix("a=rtpmap:")
             && let Some((pt, codec)) = rest.split_once(' ')
         {
-            let codec_name = codec.split('/').next().unwrap_or(codec).trim();
-            pt_to_codec.insert(pt.to_string(), codec_name.to_ascii_uppercase());
+            let payload = payloads.entry(pt.to_string()).or_default();
+            payload.media = current_media.clone();
+            payload.codec = codec
+                .split('/')
+                .next()
+                .unwrap_or(codec)
+                .trim()
+                .to_ascii_uppercase();
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("a=fmtp:")
+            && let Some((pt, params)) = rest.split_once(' ')
+            && let Some(apt) = params
+                .split(';')
+                .find_map(|p| p.trim().strip_prefix("apt="))
+        {
+            payloads.entry(pt.to_string()).or_default().apt = Some(apt.trim().to_string());
         }
     }
 
-    let mut disabled_pts = HashSet::new();
-    for (pt, codec) in pt_to_codec.iter() {
-        if disabled.contains(codec) {
-            disabled_pts.insert(pt.clone());
+    // Base codecs are judged by name against their media type's whitelist;
+    // associated payloads (e.g. RTX) are removed along with their apt base.
+    let mut removed_pts: HashSet<String> = HashSet::new();
+    for (pt, payload) in &payloads {
+        if payload.apt.is_some() {
+            continue;
+        }
+        let allowed = match payload.media.as_str() {
+            "video" => video_whitelist.is_empty() || video_whitelist.contains(&payload.codec),
+            "audio" => audio_whitelist.is_empty() || audio_whitelist.contains(&payload.codec),
+            _ => true,
+        };
+        if !allowed {
+            removed_pts.insert(pt.clone());
+        }
+    }
+    loop {
+        let mut changed = false;
+        for (pt, payload) in &payloads {
+            if let Some(base) = &payload.apt
+                && removed_pts.contains(base)
+                && removed_pts.insert(pt.clone())
+            {
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
         }
     }
 
-    if disabled_pts.is_empty() {
+    if removed_pts.is_empty() {
         return Ok(sdp.to_string());
     }
 
@@ -47,7 +116,7 @@ pub fn maybe_filter_codecs(sdp: &str, disabled_codecs: &[String]) -> Result<Stri
             let head = parts.drain(0..3).collect::<Vec<_>>().join(" ");
             let payloads: Vec<&str> = parts
                 .into_iter()
-                .filter(|pt| !disabled_pts.contains(*pt))
+                .filter(|pt| !removed_pts.contains(*pt))
                 .collect();
             if payloads.is_empty() {
                 removed_media.insert(media);
@@ -62,7 +131,7 @@ pub fn maybe_filter_codecs(sdp: &str, disabled_codecs: &[String]) -> Result<Stri
             .or_else(|| line.strip_prefix("a=fmtp:"))
             .or_else(|| line.strip_prefix("a=rtcp-fb:"))
             && let Some((pt, _)) = rest.split_once(' ')
-            && disabled_pts.contains(pt)
+            && removed_pts.contains(pt)
         {
             continue;
         }
@@ -74,10 +143,86 @@ pub fn maybe_filter_codecs(sdp: &str, disabled_codecs: &[String]) -> Result<Stri
         let mut list = removed_media.into_iter().collect::<Vec<_>>();
         list.sort();
         return Err(anyhow!(
-            "Disabled codecs removed all payloads for media: {}",
+            "Codec whitelist removed all payloads for media: {}",
             list.join(", ")
         ));
     }
 
     Ok(output.join("\n"))
+}
+
+fn normalize(codecs: &[String]) -> HashSet<String> {
+    codecs
+        .iter()
+        .map(|c| c.trim().to_ascii_uppercase())
+        .filter(|c| !c.is_empty())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const OFFER: &str = "v=0\r
+o=- 0 0 IN IP4 127.0.0.1\r
+s=-\r
+t=0 0\r
+m=video 9 UDP/TLS/RTP/SAVPF 96 97 102 103\r
+a=rtpmap:96 VP8/90000\r
+a=rtcp-fb:96 nack\r
+a=rtpmap:97 rtx/90000\r
+a=fmtp:97 apt=96\r
+a=rtpmap:102 H264/90000\r
+a=fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f\r
+a=rtcp-fb:102 nack\r
+a=rtpmap:103 rtx/90000\r
+a=fmtp:103 apt=102\r
+m=audio 9 UDP/TLS/RTP/SAVPF 111 0\r
+a=rtpmap:111 opus/48000/2\r
+a=fmtp:111 minptime=10;useinbandfec=1\r
+a=rtpmap:0 PCMU/8000";
+
+    fn strs(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn empty_whitelists_keep_sdp() {
+        assert_eq!(maybe_filter_codecs(OFFER, &[], &[]).unwrap(), OFFER);
+    }
+
+    #[test]
+    fn video_whitelist_keeps_rtx_of_allowed_codec() {
+        let out = maybe_filter_codecs(OFFER, &strs(&["H264"]), &[]).unwrap();
+        assert!(out.contains("m=video 9 UDP/TLS/RTP/SAVPF 102 103"));
+        // VP8 and its RTX are gone, including fmtp/rtcp-fb lines
+        assert!(!out.contains("VP8"));
+        assert!(!out.contains("apt=96"));
+        assert!(!out.contains("a=rtcp-fb:96"));
+        // H264 RTX follows its base codec even though "RTX" is not whitelisted
+        assert!(out.contains("a=rtpmap:103 rtx/90000"));
+        // audio is unrestricted
+        assert!(out.contains("m=audio 9 UDP/TLS/RTP/SAVPF 111 0"));
+    }
+
+    #[test]
+    fn audio_whitelist_filters_audio_only() {
+        let out = maybe_filter_codecs(OFFER, &[], &strs(&["OPUS"])).unwrap();
+        assert!(out.contains("m=audio 9 UDP/TLS/RTP/SAVPF 111"));
+        assert!(!out.contains("PCMU"));
+        // video is unrestricted
+        assert!(out.contains("m=video 9 UDP/TLS/RTP/SAVPF 96 97 102 103"));
+    }
+
+    #[test]
+    fn whitelist_is_case_insensitive() {
+        let out = maybe_filter_codecs(OFFER, &strs(&["h264"]), &[]).unwrap();
+        assert!(out.contains("m=video 9 UDP/TLS/RTP/SAVPF 102 103"));
+    }
+
+    #[test]
+    fn whitelist_emptying_media_section_errors() {
+        let err = maybe_filter_codecs(OFFER, &strs(&["VP9"]), &[]).unwrap_err();
+        assert!(err.to_string().contains("video"), "unexpected: {err}");
+    }
 }

--- a/liveion/src/route/whep.rs
+++ b/liveion/src/route/whep.rs
@@ -26,7 +26,11 @@ async fn whep(
     if content_type.to_str()? != "application/sdp" {
         return Err(anyhow::anyhow!("Content-Type must be application/sdp").into());
     }
-    let filtered_sdp = maybe_filter_codecs(&body, &state.config.sdp.disable_codecs)?;
+    let filtered_sdp = maybe_filter_codecs(
+        &body,
+        &state.config.sdp.video_codecs,
+        &state.config.sdp.audio_codecs,
+    )?;
     let offer = RTCSessionDescription::offer(filtered_sdp)?;
     debug!("offer: {}", offer.sdp);
     let (answer, session) = match state.stream_manager.subscribe(stream.clone(), offer).await {

--- a/liveion/src/route/whip.rs
+++ b/liveion/src/route/whip.rs
@@ -27,7 +27,11 @@ async fn whip(
     if content_type.to_str()? != "application/sdp" {
         return Err(anyhow::anyhow!("Content-Type must be application/sdp").into());
     }
-    let filtered_sdp = maybe_filter_codecs(&body, &state.config.sdp.disable_codecs)?;
+    let filtered_sdp = maybe_filter_codecs(
+        &body,
+        &state.config.sdp.video_codecs,
+        &state.config.sdp.audio_codecs,
+    )?;
     let offer = RTCSessionDescription::offer(filtered_sdp)?;
     debug!("offer: {}", offer.sdp);
     let (answer, session) = state.stream_manager.publish(stream.clone(), offer).await?;


### PR DESCRIPTION
## What

Replace the `[sdp] disable_codecs` blacklist with per-media-type codec whitelists:

```toml
[sdp]
# video_codecs = ["H264"]
# audio_codecs = ["OPUS"]
```

- Empty or omitted list = no restriction for that media type (default behavior unchanged).
- Audio and video whitelists are separate, so constraining one type doesn't require enumerating every codec of the other.
- Codec-associated payloads (e.g. RTX retransmission) now follow the codec they reference via `fmtp apt=`: RTX is kept when its base codec is allowed (no need to whitelist "RTX") and removed together with its base (fixes the previous behavior that left orphaned RTX payloads in the m-line).
- If a whitelist removes all payloads of a media section, the offer is rejected with an error naming the media type.

## Why

The setting exists for controlled pipelines (e.g. recorder-only). A whitelist is fail-safe there: codecs newly supported by the SFU are excluded by default instead of silently becoming negotiable, and typos fail loudly instead of silently doing nothing.

## Compatibility

Breaking config change: `disable_codecs` is removed (silently ignored by serde if still present in existing configs).

## Tests

5 new unit tests in `liveion/src/route/sdp.rs` covering: empty whitelists, video whitelist keeping the allowed codec's RTX, audio-only filtering, case insensitivity, and erroring when a media section is emptied. `cargo clippy -p liveion --all-targets -- -D warnings` clean, `cargo test -p liveion --lib` 65/65 pass.