### PR TITLE
refactor(auth): replace jsonwebtoken with a minimal ring-based HS256 JWT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,11 +290,13 @@ dependencies = [
  "anyhow",
  "api",
  "axum 0.8.9",
+ "base64 0.22.1",
  "headers",
  "http 1.4.2",
  "http-body 1.0.1",
- "jsonwebtoken",
+ "ring",
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1132,7 +1134,6 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -1386,30 +1387,6 @@ dependencies = [
  "rfc6979",
  "signature",
  "spki",
-]
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -2388,28 +2365,6 @@ dependencies = [
  "pest",
  "pest_derive",
  "serde",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "10.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
-dependencies = [
- "base64 0.22.1",
- "ed25519-dalek",
- "getrandom 0.2.17",
- "hmac",
- "js-sys",
- "p256",
- "p384",
- "rand 0.8.6",
- "rsa",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "signature",
- "zeroize",
 ]
 
 [[package]]

--- a/libs/auth/Cargo.toml
+++ b/libs/auth/Cargo.toml
@@ -17,4 +17,6 @@ http-body = { workspace = true }
 serde = { workspace = true, features = ["serde_derive"] }
 
 headers = "0.4"
-jsonwebtoken = { version = "10", default-features = false, features = ["rust_crypto"] }
+ring = "0.17"
+base64 = { workspace = true }
+serde_json = { workspace = true }

--- a/libs/auth/src/jwt.rs
+++ b/libs/auth/src/jwt.rs
@@ -1,0 +1,129 @@
+//! Minimal HS256 (HMAC-SHA256) JWT encode/decode.
+//!
+//! Replaces the `jsonwebtoken` crate: Live777 only ever issues and verifies
+//! HMAC-signed tokens, but `jsonwebtoken` links the RSA/ECDSA/JWKS machinery
+//! for every algorithm (~300 KiB in the release binary) because the algorithm
+//! is dispatched at runtime. `ring` is already in the dependency graph
+//! (WebRTC DTLS), so this module adds no new native code.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Error, anyhow};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use ring::hmac;
+
+use crate::claims::Claims;
+
+/// Serialized JWT header, byte-identical to `jsonwebtoken::Header::default()`.
+const HEADER_JSON: &str = r#"{"typ":"JWT","alg":"HS256"}"#;
+
+/// Matches `jsonwebtoken::Validation::default()` leeway.
+const EXPIRY_LEEWAY_SECS: u64 = 60;
+
+pub fn encode(claims: &Claims, secret: &[u8]) -> Result<String, Error> {
+    let mut token = URL_SAFE_NO_PAD.encode(HEADER_JSON);
+    token.push('.');
+    token.push_str(&URL_SAFE_NO_PAD.encode(serde_json::to_vec(claims)?));
+    let key = hmac::Key::new(hmac::HMAC_SHA256, secret);
+    let signature = hmac::sign(&key, token.as_bytes());
+    token.push('.');
+    token.push_str(&URL_SAFE_NO_PAD.encode(signature.as_ref()));
+    Ok(token)
+}
+
+pub fn decode(token: &str, secret: &[u8]) -> Result<Claims, Error> {
+    let (message, signature_b64) = token
+        .rsplit_once('.')
+        .ok_or_else(|| anyhow!("invalid token: missing signature"))?;
+    let (header_b64, payload_b64) = message
+        .split_once('.')
+        .ok_or_else(|| anyhow!("invalid token: missing payload"))?;
+
+    let header: serde_json::Value = serde_json::from_slice(&URL_SAFE_NO_PAD.decode(header_b64)?)?;
+    if header.get("alg").and_then(|alg| alg.as_str()) != Some("HS256") {
+        return Err(anyhow!("invalid token: unsupported algorithm"));
+    }
+
+    let key = hmac::Key::new(hmac::HMAC_SHA256, secret);
+    let signature = URL_SAFE_NO_PAD.decode(signature_b64)?;
+    hmac::verify(&key, message.as_bytes(), &signature)
+        .map_err(|_| anyhow!("invalid token: signature mismatch"))?;
+
+    let claims: Claims = serde_json::from_slice(&URL_SAFE_NO_PAD.decode(payload_b64)?)?;
+    let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+    if claims.exp < now.saturating_sub(EXPIRY_LEEWAY_SECS) {
+        return Err(anyhow!("invalid token: expired"));
+    }
+    Ok(claims)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &[u8] = b"secret";
+    /// Precomputed HS256 token for `{"id":"test","exp":4102444800,"mode":7}`
+    /// with secret `secret` (HMAC-SHA256, verified against an independent
+    /// implementation).
+    const KNOWN_TOKEN: &str = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpZCI6InRlc3QiLCJleHAiOjQxMDI0NDQ4MDAsIm1vZGUiOjd9.PH1OihSKeduwvmBYxnz_mOhvk53aYD1J-31besrOjuM";
+
+    fn claims() -> Claims {
+        Claims {
+            id: "test".to_string(),
+            exp: 4102444800, // 2100-01-01
+            mode: 7,
+        }
+    }
+
+    #[test]
+    fn encode_matches_known_vector() {
+        assert_eq!(encode(&claims(), SECRET).unwrap(), KNOWN_TOKEN);
+    }
+
+    #[test]
+    fn roundtrip() {
+        let token = encode(&claims(), SECRET).unwrap();
+        let decoded = decode(&token, SECRET).unwrap();
+        assert_eq!(decoded.id, "test");
+        assert_eq!(decoded.exp, 4102444800);
+        assert_eq!(decoded.mode, 7);
+    }
+
+    #[test]
+    fn decode_known_vector() {
+        let decoded = decode(KNOWN_TOKEN, SECRET).unwrap();
+        assert_eq!(decoded.id, "test");
+    }
+
+    #[test]
+    fn rejects_wrong_secret() {
+        assert!(decode(KNOWN_TOKEN, b"wrong").is_err());
+    }
+
+    #[test]
+    fn rejects_tampered_payload() {
+        let token = KNOWN_TOKEN.replace("InRlc3Qi", "InRlc3Qy");
+        assert!(decode(&token, SECRET).is_err());
+    }
+
+    #[test]
+    fn rejects_non_hs256_alg() {
+        // header {"alg":"none"}
+        let token = "eyJhbGciOiJub25lIn0.eyJpZCI6InRlc3QiLCJleHAiOjQxMDI0NDQ4MDAsIm1vZGUiOjd9.";
+        assert!(decode(token, SECRET).is_err());
+    }
+
+    #[test]
+    fn rejects_expired() {
+        let mut expired = claims();
+        expired.exp = 1_000_000; // 1970
+        let token = encode(&expired, SECRET).unwrap();
+        assert!(decode(&token, SECRET).is_err());
+    }
+
+    #[test]
+    fn rejects_garbage() {
+        assert!(decode("not-a-token", SECRET).is_err());
+        assert!(decode("a.b.c", SECRET).is_err());
+    }
+}

--- a/libs/auth/src/lib.rs
+++ b/libs/auth/src/lib.rs
@@ -1,9 +1,8 @@
 use std::collections::HashSet;
 
-use anyhow::{Error, anyhow};
+use anyhow::Error;
 use headers::authorization::{Bearer, Credentials};
 use http::{StatusCode, header};
-use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation, decode, encode};
 
 use axum::{
     extract::{Request, State},
@@ -15,36 +14,37 @@ use crate::claims::Claims;
 
 pub mod access;
 pub mod claims;
+mod jwt;
 
 pub const ANY_ID: &str = "*";
 
 pub struct Keys {
-    encoding: EncodingKey,
+    secret: Vec<u8>,
 }
 
 impl Keys {
     pub fn new(secret: &[u8]) -> Self {
         Self {
-            encoding: EncodingKey::from_secret(secret),
+            secret: secret.to_vec(),
         }
     }
 
     pub fn token(self, claims: Claims) -> Result<String, Error> {
-        encode(&Header::default(), &claims, &self.encoding).map_err(|e| anyhow!(e))
+        jwt::encode(&claims, &self.secret)
     }
 }
 
 #[derive(Clone)]
 pub struct AuthState {
     tokens: HashSet<String>,
-    decoding: DecodingKey,
+    secret: Vec<u8>,
 }
 
 impl AuthState {
     pub fn new(secret: String, tokens: Vec<String>) -> Self {
         Self {
             tokens: tokens.into_iter().collect(),
-            decoding: DecodingKey::from_secret(secret.as_bytes()),
+            secret: secret.into_bytes(),
         }
     }
 }
@@ -75,10 +75,8 @@ pub async fn validate_middleware(
                     return true;
                 }
                 Some(bearer) => {
-                    if let Ok(token_data) =
-                        decode::<Claims>(bearer.token(), &state.decoding, &Validation::default())
-                    {
-                        request.extensions_mut().insert(token_data.claims);
+                    if let Ok(claims) = jwt::decode(bearer.token(), &state.secret) {
+                        request.extensions_mut().insert(claims);
                         return true;
                     }
                 }


### PR DESCRIPTION
## Why

Live777 only ever issues and verifies HMAC-signed (HS256) tokens (`libs/auth` uses `EncodingKey::from_secret` + `Validation::default()`). But `jsonwebtoken` dispatches the algorithm at runtime from the token header, so the RSA/ECDSA/JWKS machinery for **every** algorithm stays reachable and cannot be dead-code-eliminated — ~0.5 MiB in the release-size binary (measured with `nm`/cargo bloat: jsonwebtoken 231 KiB of symbols plus the `rsa`/`simple_asn1`/JWKS chain).

## What

Replace `jsonwebtoken` with a small `ring`-based HS256 implementation (`libs/auth/src/jwt.rs`, ~80 lines + tests):

- `ring` is already in the dependency graph (WebRTC DTLS), so no new native code is pulled in; `jsonwebtoken` and `rsa` leave the dependency tree entirely.
- The serialized JWT header is byte-identical to `jsonwebtoken::Header::default()`, and validation keeps the default 60s expiry leeway — previously minted tokens keep verifying, and the `Keys`/`AuthState` API used by `liveman`/`liveion` is unchanged.
- Behavior coverage: unit tests include a known HS256 vector computed with an independent implementation (interop), tampered payload, wrong secret, `alg:none`, expired token, and garbage input.

## Size impact (release-size profile, x86_64 Linux, CI feature set)

| | bytes |
|---|---|
| before | 18,290,880 |
| after | 17,784,912 |
| **delta** | **−505,968 (−494 KiB)** |

## Checks

- `cargo test -p auth` — 9 passed
- `cargo clippy -p auth --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean