### PR TITLE
build: add release-size + UPX packaging recipes for embedded builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -367,6 +367,10 @@ carries the check.
   or `just cross-build-size <target> <features>` /
   `just cross-pack-size <target> <features>` for cross-compiled embedded
   targets (cross-rs; UPX packs foreign-arch ELFs from the host).
+  Device-pinned shortcuts cover the supported embedded presets:
+  `just rpi-pack-size` (needs `PI_SYSROOT`), `just rdk-pack-size`
+  (needs `RDK_SYSROOT`), and `just v4l2-pack-size [target]`
+  (armv7 by default).
 - **Releases**: `.github/workflows/release.yml` builds for many targets
   including x86_64, aarch64, armv7, i686, riscv64, Android, Windows, and macOS.
 - **Docs**: VitePress site in `docs/`; run `pnpm run docs:dev` / `docs:build`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,6 +359,14 @@ carries the check.
   `conf/liveman.service`.
 - **Packages**: nFPM configs in `nfpm/` build `.deb`, `.rpm`, and Arch Linux
   packages; GitHub Actions upload them to releases.
+- **Size-optimized builds are opt-in**: official release binaries use the
+  default `release` profile. For size-sensitive deployments (embedded,
+  containers) use the `release-size` profile (`Cargo.toml`: fat LTO, 1
+  codegen unit, stripped, `panic=abort`, opt-level stays 3) plus
+  `upx --best --lzma` — via `just build-size` / `just pack-size` locally,
+  or `just cross-build-size <target> <features>` /
+  `just cross-pack-size <target> <features>` for cross-compiled embedded
+  targets (cross-rs; UPX packs foreign-arch ELFs from the host).
 - **Releases**: `.github/workflows/release.yml` builds for many targets
   including x86_64, aarch64, armv7, i686, riscv64, Android, Windows, and macOS.
 - **Docs**: VitePress site in `docs/`; run `pnpm run docs:dev` / `docs:build`.

--- a/justfile
+++ b/justfile
@@ -68,6 +68,23 @@ cross-build-size target features="webui":
 cross-pack-size target features="webui": (cross-build-size target features)
     upx --best --lzma target/{{target}}/release-size/live777 || echo "warning: UPX cannot pack {{target}}, leaving the binary unpacked"
 
+# Raspberry Pi (native-rpi: libcamera + V4L2 capture, V4L2 M2M encoder)
+[group('embedded')]
+rpi-pack-size:
+    test -n "${PI_SYSROOT:?set PI_SYSROOT to the Raspberry Pi sysroot first (see AGENTS.md)}" && \
+        just cross-pack-size aarch64-unknown-linux-gnu native-rpi,webui
+
+# RDK X5 (native-rdk: V4L2 capture, RDK BPU encoder)
+[group('embedded')]
+rdk-pack-size:
+    test -n "${RDK_SYSROOT:?set RDK_SYSROOT to the RDK sysroot first (see AGENTS.md)}" && \
+        just cross-pack-size aarch64-unknown-linux-gnu native-rdk,webui
+
+# Generic V4L2 device (native-generic-v4l2; override the target for 64-bit boards)
+[group('embedded')]
+v4l2-pack-size target="armv7-unknown-linux-gnueabihf":
+    just cross-pack-size {{target}} native-generic-v4l2,webui
+
 # MacOS:
 #   brew install gstreamer
 # Debian:

--- a/justfile
+++ b/justfile
@@ -40,6 +40,34 @@ build:
     pnpm run build
     cargo build --release --all-targets --all-features
 
+# Size-optimized build: fat LTO, 1 codegen unit, stripped, panic=abort
+# (same feature set as the release workflow)
+[group('build')]
+build-size:
+    cargo build --profile release-size --bins \
+        --features source-all,webui,net4mqtt,recorder,cascade,whepwright,target-whip
+
+# Extreme size build: build-size + UPX LZMA (needs upx installed)
+[group('build')]
+pack-size: build-size
+    upx --best --lzma target/release-size/live777 target/release-size/liveman target/release-size/whepfrom target/release-size/whipinto target/release-size/net4mqtt
+
+# Examples:
+#   just cross-build-size aarch64-unknown-linux-gnu native-rpi,webui   # Raspberry Pi (needs PI_SYSROOT)
+#   just cross-build-size armv7-unknown-linux-gnueabihf native-generic-v4l2,webui
+#   just cross-build-size aarch64-unknown-linux-musl webui             # static musl, no native capture
+# Cross-compile a size-optimized live777 for an embedded target
+# (needs cross <https://github.com/cross-rs/cross> and docker)
+[group('build')]
+cross-build-size target features="webui":
+    cross build --target {{target}} --bin live777 --profile release-size \
+        --no-default-features --features {{features}}
+
+# cross-build-size + UPX LZMA; UPX packs foreign-arch ELFs directly from the host
+[group('build')]
+cross-pack-size target features="webui": (cross-build-size target features)
+    upx --best --lzma target/{{target}}/release-size/live777 || echo "warning: UPX cannot pack {{target}}, leaving the binary unpacked"
+
 # MacOS:
 #   brew install gstreamer
 # Debian:


### PR DESCRIPTION
## Why

Making `release-size` + UPX the default for GitHub Actions release builds was reconsidered (see discussion): UPX-packed binaries bring real costs (Windows AV heuristics flag them, they are opaque to SBOM/CVE scanners, and targets UPX cannot pack would produce inconsistent artifacts) while barely shrinking the tar.gz/zip that users actually download — a gzipped tarball of the stripped binary is already about the same size as the UPX-packed file.

Where small binaries genuinely matter is **size-sensitive embedded and container deployments**, and those are usually cross-compiled. So this makes it an opt-in local workflow instead of a release-pipeline default.

## What

justfile recipes (no changes to the release workflow or nFPM configs):

- `just build-size` — native build with the existing `release-size` profile (fat LTO, 1 codegen unit, stripped, `panic=abort`; `opt-level` stays 3, so **runtime performance is unaffected**).
- `just pack-size` — `build-size` + `upx --best --lzma` on the five binaries. Verified locally: 52.0 MB → 15.8 MB total, packed `live777 --version` runs normally.
- `just cross-build-size <target> [features]` — the same via cross-rs for embedded targets, e.g.:
  - `just cross-build-size aarch64-unknown-linux-gnu native-rpi,webui` (Raspberry Pi, needs `PI_SYSROOT`)
  - `just cross-build-size armv7-unknown-linux-gnueabihf native-generic-v4l2,webui`
  - `just cross-build-size aarch64-unknown-linux-musl webui` (static musl)
- `just cross-pack-size <target> [features]` — `cross-build-size` + UPX; UPX packs foreign-arch ELFs directly from the host, and targets UPX cannot pack are left unpacked with a warning instead of failing.
- Device-pinned shortcuts for the supported embedded presets: `just rpi-pack-size` (checks `PI_SYSROOT`), `just rdk-pack-size` (checks `RDK_SYSROOT`), `just v4l2-pack-size [target]` (armv7 + native-generic-v4l2 by default).

`AGENTS.md` documents the opt-in pipeline.

## Size reference (x86_64-linux, release feature set, live777)

| stage | size |
|---|---|
| default `release` (official releases, unchanged) | 38.0 MB |
| `release-size` | 17.8 MB |
| `release-size` + `upx --best --lzma` | 5.0 MB |